### PR TITLE
Make node-inspector installable via npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "node-inspector",
+    "version": "0.0.1",
+    "description": "Web Inspector based nodeJS debugger",
+    "homepage": "http://github.com/dannycoates/node-inspector",
+    "author": "Danny Coates <dannycoates@gmail.com>",
+    "keywords": ["debugger", "inspector"],
+    "engines" : { "node": ">= 0.1.101" },
+    "bin" : { "node-inspector" : "./bin/inspector.js" }
+}


### PR DESCRIPTION
This would help users of node-inspector get it installed. On a more personal note, it would also simplify the installation instructions for users of the nodify IDE that depends on node-inspector.
