### PR TITLE
Improve support for user stylesheets

### DIFF
--- a/front-end/index.html
+++ b/front-end/index.html
@@ -26,7 +26,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 <!DOCTYPE html>
-<html>
+<html class="node-inspector">
 <head>
     <title>nodeJS Inspector</title>
     <meta http-equiv="content-type" content="text/html; charset=utf-8">

--- a/front-end/inspector.html
+++ b/front-end/inspector.html
@@ -26,7 +26,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 <!DOCTYPE html>
-<html>
+<html class="node-inspector">
 <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <link rel="stylesheet" type="text/css" href="audits.css">


### PR DESCRIPTION
Currently WebKit based browsers only support _global_ user stylesheets.
That means the rules you put in the stylesheet will be used for _all_
websites you visit, and even more, for the browser's chrome itself.

Until an equivalent @-moz-document rule is implemented, the only solution
seems to be CSS class namespacing.

By providing a `node-inspector` class on the `html` element, users can
now tweak the UI of node-inspector without messing up the browser's chrome.
For example, in order to increase the font size of code blocks, you'd put
this in your user stylesheet:

  html.node-inspector body.platform-mac .monospace,
  html.node-inspector body.platform-mac .source-code {
    font-size: 13px !important;
  }

See also:
- http://code.google.com/p/chromium/issues/detail?id=2393
- https://bugs.webkit.org/show_bug.cgi?id=51172
