### PR TITLE
Node-inspector stops working when Watch Expressions panel contains non-ASCII characters

### DIFF
--- a/lib/debugger.js
+++ b/lib/debugger.js
@@ -71,7 +71,8 @@ exports.attachDebugger = function(port) {
       value: function(data)
       {
         if (connected) {
-          conn.write('Content-Length: ' + data.length + '\r\n\r\n' + data);
+          var dataBuffer = new Buffer(data);
+          conn.write('Content-Length: ' + dataBuffer.length + '\r\n\r\n' + dataBuffer);
         }
       }
     },


### PR DESCRIPTION
When I enter non-ASCII characters into Watch Expressions panel debugging session crashes. After that I have to clear browser Local Storage as node-inspector saves all watch expressions there.

The problem with non-ASCII characters is that V8 remote debugger expects the length of the whole message to be sent in Content-Length header. But simple data.length works for ASCII characters only. So the Content-Length should be calculated through Buffer class.

Nodejs v0.6.17 on Windows 7 x64
