### PR TITLE
Switch default listening printing address to 127.0.0.1

### DIFF
--- a/lib/debug-server.js
+++ b/lib/debug-server.js
@@ -48,7 +48,7 @@ function handleWebSocketConnection(socket) {
 
 function handleServerListening() {
   console.log(
-    'visit http://' + (config.webHost || '0.0.0.0') + ':' +
+    'visit http://' + (config.webHost || '127.0.0.1') + ':' +
     config.webPort +
     '/debug?port=' + config.debugPort + ' to start debugging');
 }


### PR DESCRIPTION
Hi!

I know that this change isn't relevant, but I think that printing 127.0.0.1 is much better than 0.0.0.0 in the "visit to start debugging" message. 

The reasons? 0.0.0.0 makes sense to get the node-inspector binded to all interfaces, yes, but for browsing local resources the most common practice is by using the "localhost" or the "127.0.0.1" address.

Kind regards!
