### PR TITLE
Added a command line option : --debug-port

### DIFF
--- a/bin/inspector.js
+++ b/bin/inspector.js
@@ -16,7 +16,10 @@ process.argv.forEach(function (arg) {
         break;
       case '--web-host':
         options.webHost = (parts[1] && parts[1] !== 'null') ? parts[1] : null;
-	break;
+        break;
+      case '--debug-port':
+        options.debugPort = parseInt(parts[1], 10)
+        break;
       default:
         console.log('unknown option: ' + parts[0]);
         break;
@@ -26,6 +29,7 @@ process.argv.forEach(function (arg) {
       console.log('Usage: node-inspector [options]');
       console.log('Options:');
       console.log('--web-port=[port]     port to host the inspector (default 8080)');
+      console.log('--debug-port=[port]   port to node debugger (default 5858)');
       process.exit();
     }
   }
@@ -60,6 +64,9 @@ fs.readFile(path.join(__dirname, '../config.json'), function(err, data) {
   }
   if (options.webHost) {
     config.webHost = options.webHost;
+  }
+  if (options.debugPort) {
+    config.debugPort = options.debugPort;
   }
 
   debugServer = new DebugServer();


### PR DESCRIPTION
Hi,
I added an option for node-inspector since I found it useful when I work with other engineers in a same machine.
With --debug-port specified, mutiple node-inspector instances can run at the same time which enables multiple developers to debug their codes simultaneously and independently on a single server.
To use this option, specify debug port in node command as well.
Ex)
$ node --debug-brk=5859 server.js
$ node-inspector --debug-port=5859 --web-port=8080

Thanks.
