### PR TITLE
Upgrade sock.io dependency so that node-inspector can work with node v0.10.x

### DIFF
--- a/lib/debug-server.js
+++ b/lib/debug-server.js
@@ -1,7 +1,8 @@
 var Http = require('http'),
     EventEmitter = require('events').EventEmitter,
     io = require('socket.io'),
-    paperboy = require('paperboy'),
+    send = require('send'),
+    url = require('url'),
     Session = require('./session'),
     inherits = require('util').inherits,
     WEBROOT = require('path').join(__dirname, '../front-end'),
@@ -16,7 +17,7 @@ function serveStaticFiles(req, res) {
     config.debugPort = getDebuggerPort(req.url, config.debugPort);
     req.url = req.url.replace(re, '/');
   }
-  paperboy.deliver(WEBROOT, req, res);
+  send(req, url.parse(req.url).pathname).root(WEBROOT).pipe(res);
 }
 
 function getDebuggerPort(url, defaultPort) {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "bin" : { "node-inspector" : "./bin/inspector.js" },
     "dependencies": {
       "socket.io": "~0.9.13",
-      "paperboy": "~0.0.5"
+      "paperboy": "~0.0.5",
+      "send": "0.1.x"
     }
 }


### PR DESCRIPTION
node-inspector cannot be used to debug node v0.10.x anymore as breakpoints are not trapped. Upgrading to latest socket.io fixes the problem.
