### PR TITLE
PageAgent: improved main-file detection + REPL fixes

### DIFF
--- a/lib/PageAgent.js
+++ b/lib/PageAgent.js
@@ -44,10 +44,13 @@ PageAgent.prototype = {
   },
 
   _doGetResourceTree: function(params, done) {
+    var describeProgram = '[process.cwd(), ' +
+      'process.mainModule ? process.mainModule.filename : process.argv[1]]';
+
     async.waterfall(
       [
         this._debuggerClient.evaluateGlobal
-          .bind(this._debuggerClient, '[process.cwd(), process.argv[1]]'),
+          .bind(this._debuggerClient, describeProgram),
         function(evaluateResult, cb) {
           cb(null, evaluateResult[0], evaluateResult[1]);
         },
@@ -59,6 +62,11 @@ PageAgent.prototype = {
   },
 
   _resolveMainAppScript: function(startDirectory, mainAppScript, done) {
+    if (mainAppScript == null) {
+      // mainScriptFile is null when running in the REPL mode
+      return done(null, startDirectory, mainAppScript);
+    }
+
     fs.stat(mainAppScript, function(err, stat) {
       if (err && !/\.js$/.test(mainAppScript)) {
         mainAppScript += '.js';
@@ -113,6 +121,18 @@ PageAgent.prototype = {
 
   getResourceContent: function(params, done) {
     var scriptName = convert.inspectorUrlToV8Name(params.url);
+
+    if (scriptName === '') {
+      // When running REPL, main application file is null
+      // and node inspector returns an empty string to the front-end.
+      // However, front-end still asks for resource content.
+      // Let's return a descriptive comment then.
+      var content = '// There is no main module loaded in node.\n' +
+        '// This is expected when you are debugging node\'s interactive REPL console.';
+
+      return process.nextTick(
+        this._convertScriptSourceToGetResourceResponse.bind(this, content, done));
+    }
 
     async.waterfall(
       [

--- a/lib/ScriptFileStorage.js
+++ b/lib/ScriptFileStorage.js
@@ -136,6 +136,11 @@ $class.listScripts = function(rootFolder, callback) {
 };
 
 $class._findScriptsOfRunningApp = function(mainScriptFile, callback) {
+  if (!mainScriptFile) {
+    // mainScriptFile is null when running in the REPL mode
+    return process.nextTick(callback.bind(null, null, []));
+  }
+
   async.waterfall(
     [
       this.findApplicationRoot.bind(this, mainScriptFile),

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -14,9 +14,15 @@ exports.v8LocationToInspectorLocation = function(v8loc) {
 // UNC       \\SHARE\app.js  file://SHARE/app.js
 
 exports.v8NameToInspectorUrl = function(v8name) {
-  if (v8name === undefined) {
-    // Call to `evaluate` creates a new script with no URL
-    // Front-end expects empty string as URL in such case
+  if (!v8name || v8name === 'repl') {
+    // Call to `evaluate` from user-land creates a new script with undefined URL.
+    // REPL has null main script file and calls `evaluate` with `repl`
+    // as the file name.
+    //
+    // When we send an empty string as URL, front-end opens the source
+    // as VM-only script (named "[VM] {script-id}").
+    //
+    // The empty name of the main script file is displayed as "(program)".
     return '';
   }
 


### PR DESCRIPTION
Fixed the way how we detect the main application file for two cases:
  `node .` (run the local application)
  `node --debug` (start an interactive REPL session)

Fixed also other issues that prevented debugging of REPL sessions.

@Schoonology please review
