### PR TITLE
Bugfix: crash when breakpoint was hit in eval()-ed

### DIFF
--- a/lib/BreakEventHandler.js
+++ b/lib/BreakEventHandler.js
@@ -44,7 +44,15 @@ BreakEventHandler.prototype._onBreak = function(obj) {
   var scriptId = obj.script.id,
     source = this._scriptManager.findScriptByID(scriptId);
 
-  if (source.hidden) {
+  // Source is undefined when the breakpoint was in code eval()-ed via
+  // console or eval()-ed internally by node inspector.
+  // We could send backtrace in such case, but that isn't working well now.
+  // V8 is reusing the same scriptId for multiple eval() calls and DevTools
+  // front-end does not update the displayed source code when a content
+  // of a script changes.
+  // The following solution - ignore the breakpoint and resume the
+  // execution - should be good enough in most cases.
+  if (!source || source.hidden) {
     this._debuggerClient.request('continue', { stepaction: 'out' });
     return;
   }


### PR DESCRIPTION
Fixed the bug #198 where Node Inspector crashed when a breakpoint was hit in a code
run by eval(). This is happening in two cases:
- Node Inspector calls eval() to get more information about the debugged
  process. In certain circumstances it was possible that the debugger stopped
  inside this code.
- User types `debugger;` in the console panel.

BreakEventHandler was changed to resume the execution in both cases, as if
the sources were hidden.

@Schoonology please review.
