### PR TITLE
Quick fix for properties displayed twice in UI

### DIFF
--- a/lib/RuntimeAgent.js
+++ b/lib/RuntimeAgent.js
@@ -169,9 +169,26 @@ RuntimeAgent.prototype = {
     },
 
   getProperties: function(params, done) {
+    // TODO implement the new way of getting object properties
+    //
+    // Front-end sends the following two requests for Object properties:
+    // "params": {"objectId":"78","ownProperties":false,"accessorPropertiesOnly":true}
+    // "params":{"objectId":"78","ownProperties":true,"accessorPropertiesOnly":false}
+    //
+    // Or the following request for Scope properties:
+    // "params":{"objectId":"scope:0:2","ownProperties":false,"accessorPropertiesOnly":false}
+    // See getProperties() and getInjectedProperties() in
+    //   http://src.chromium.org/blink/branches/chromium/1625/Source/core/
+    //    inspector/InjectedScriptSource.js
+    // for more details.
     if (this._callFramesProvider.isScopeId(params.objectId)) {
       this._getPropertiesOfScopeId(params.objectId, done);
     } else {
+      if (!params.ownProperties || params.accessorPropertiesOnly) {
+        // Temporary fix for missing getInternalProperties() implementation
+        // See the comment above and GH issue #213
+        return done(null, { result: [] });
+      }
       this._getPropertiesOfObjectId(params.objectId, done);
     }
   },

--- a/test/RuntimeAgent.js
+++ b/test/RuntimeAgent.js
@@ -24,11 +24,13 @@ describe('RuntimeAgent', function() {
 
         agent.getProperties(
           {
-            objectId: MYFUNC_LOCAL_SCOPE_ID
+            objectId: MYFUNC_LOCAL_SCOPE_ID,
+            ownProperties: false,
+            accessorPropertiesOnly: false
           },
           function(error, result) {
             if (error)
-              done(error);
+              return done(error);
 
             expect(result.result.length, 'number of local variables')
               .to.equal(2);
@@ -65,11 +67,13 @@ describe('RuntimeAgent', function() {
       var agent = new RuntimeAgent(debuggerClient);
       agent.getProperties(
         {
-          objectId: inspectedObjectId
+          objectId: inspectedObjectId,
+          ownProperties: true,
+          accessorPropertiesOnly: false
         },
         function(error, result) {
           if (error)
-            done(error);
+            return done(error);
 
           var props = convertPropertyArrayToLookup(result.result);
 
@@ -88,6 +92,25 @@ describe('RuntimeAgent', function() {
           done();
         }
       );
+    });
+  });
+
+  it('returns empty result for unsupported getProperties() call', function(done) {
+    launcher.runInspectObject(function(debuggerClient, inspectedObjectId) {
+      var agent = new RuntimeAgent(debuggerClient);
+      agent.getProperties(
+        {
+          objectId: inspectedObjectId,
+          ownProperties: false,
+          accessorPropertiesOnly: true
+        },
+        function(error, result) {
+          if (error)
+            return done(error);
+
+          expect(result.result).to.be.empty;
+          done();
+        });
     });
   });
 
@@ -254,7 +277,9 @@ function verifyPropertyValue(runtimeAgent,
                              callback) {
   runtimeAgent.getProperties(
     {
-      objectId: objectId
+      objectId: objectId,
+      ownProperties: true,
+      accessorPropertiesOnly: false
     },
     function(err, result) {
       if (err) throw err;


### PR DESCRIPTION
The upgraded front-end sends two requests to get a list of object properties,
each request asking for a different set of variables. Because our back-end was
ignoring request parameters, the same set of variables was returned twice.

This commit fixes the immediate problem, without providing the full
implementation of the new front-end feature.

See node-inspector/node-inspector#213.

@Schoonology please review. I'll fill a new issue (Enhancement) to get the proper implementation of getProperties & getInternalProperties.
