### PR TITLE
update readme with WTF about adblock

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -176,6 +176,11 @@ List of predefined options:
   >
   > Note that the array items are interpreted as regular expressions.
 
+5. UI doesn't load or doesn't work and refresh didn't help
+
+  > Make sure that you have adblock disabled as well as any other content
+  > blocking scripts and plugins.
+
 ## Contributing Code
 
 Making Node Inspector the best debugger for node.js cannot be achieved without


### PR DESCRIPTION
Thanks to issue #220, I noticed that adblock can cause problems for node-inspector. I'm adding a note to the readme because it's a nicer place to see this rather than needing to search in issues.
