### PR TITLE
Added debug logging of communication

### DIFF
--- a/lib/FrontendClient.js
+++ b/lib/FrontendClient.js
@@ -1,5 +1,6 @@
 var EventEmitter = require('events').EventEmitter,
     inherits = require('util').inherits,
+    debugProtocol = require('debug')('node-inspector:protocol:devtools'),
     ErrorNotConnected = require('./DebuggerClient').ErrorNotConnected;
 
 /**
@@ -44,12 +45,14 @@ FrontendClient.prototype._onConnectionMessage = function(message) {
  * @param {!Object|string} message
  */
 FrontendClient.prototype._sendMessage = function(message) {
+  var payload = typeof message == 'string' ? message : JSON.stringify(message);
+  debugProtocol('backend: ' + payload);
+
   if (!this._connection) {
     console.log('Cannot send response - there is no front-end connection.');
     return;
   }
 
-  var payload = typeof message == 'string' ? message : JSON.stringify(message);
   this._connection.send(payload);
 };
 

--- a/lib/FrontendCommandHandler.js
+++ b/lib/FrontendCommandHandler.js
@@ -1,3 +1,5 @@
+var debugProtocol = require('debug')('node-inspector:protocol:devtools');
+
 var RuntimeAgent = require('./RuntimeAgent').RuntimeAgent,
   PageAgent = require('./PageAgent').PageAgent,
   NetworkAgent = require('./NetworkAgent').NetworkAgent,
@@ -99,6 +101,7 @@ FrontendCommandHandler.prototype = {
   },
 
   _handleFrontendMessage: function(message) {
+    debugProtocol('frontend: '+ message);
     var command = JSON.parse(message);
     this.handleCommand(command);
   },

--- a/lib/debugger.js
+++ b/lib/debugger.js
@@ -1,6 +1,7 @@
 var Net = require('net'),
     EventEmitter = require('events').EventEmitter,
     Buffer = require('buffer').Buffer,
+    debugProtocol = require('debug')('node-inspector:protocol:v8-debug');
     callbackHandler = require('./callback').create();
 
 function makeMessage() {
@@ -39,10 +40,15 @@ exports.attachDebugger = function(port) {
             debugr.isRunning = obj.running;
           }
           if (obj.type === 'response' && obj.request_seq > 0) {
+            debugProtocol('response: ' + msg.body);
             callbackHandler.processResponse(obj.request_seq, [obj]);
           }
           else if (obj.type === 'event') {
+            debugProtocol('event: ' + msg.body);
             debugr.emit(obj.event, obj);
+          }
+          else {
+            debugProtocol('unknown: ' + msg.body);
           }
         }
         msg = false;
@@ -76,6 +82,7 @@ exports.attachDebugger = function(port) {
     send: {
       value: function(data)
       {
+        debugProtocol('request: ' + data);
         if (connected) {
           conn.write('Content-Length: ' + data.length + '\r\n\r\n' + data);
         }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "async": "~0.2.8",
     "glob": "~3.2.1",
     "rc": "~0.3.0",
-    "strong-data-uri": "~0.1.0"
+    "strong-data-uri": "~0.1.0",
+    "debug": "~0.7.3"
   },
   "devDependencies": {
     "mocha": "latest",


### PR DESCRIPTION
Added debug logs for devtools protocol and V8 debugger protocol.

Set DEBUG=node-inspector:protocol:\* to enable.

@Schoonology Please review. I am going to use these logs in my talk about internal architecture of Node Inspector.
