### PR TITLE
fix: user defined config option will be overridden

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -146,8 +146,7 @@ function collectDefaultsFromJSONConfig() {
   }
 
   Object.keys(camelKeyOptions).forEach(function(key) {
-    var dashedKey = conversions.keyToDashedKey(key);
-    options[dashedKey] = camelKeyOptions[key];
+    options[key] = camelKeyOptions[key];
   });
 
   return options;


### PR DESCRIPTION
Project config.js file will be import as dash key style and when
`rcToInnerConfig` runs with `Object.keys`, the order of key appear is
unknow and I experience that my own configuration file in $HOME will be
override by the global one.
