### PR TITLE
Improved formatting of Date objects in inspector

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -81,8 +81,9 @@ exports.v8RefToInspectorObject = function(ref) {
           size = ref.properties.filter(function(p) { return /^\d+$/.test(p.name);}).length;
           desc += '[' + size + ']';
         }
-      }
-      else {
+      } else if (ref.className === 'Date') {
+        desc = 'Date: ' + (new Date(ref.value).toString());
+      } else {
         desc = ref.className || 'Object';
       }
       break;

--- a/test/convert.js
+++ b/test/convert.js
@@ -139,5 +139,20 @@ describe('convert', function() {
 
       expect(convert.v8RefToInspectorObject(ref).description).to.equal('Buffer[3]');
     });
+
+    it('appends formatted date to Date description by calling toString on the date', function() {
+      var ref = {
+        handle: 0,
+        type: 'object',
+        className: 'Date',
+        text: '2013-12-21T15:51:57.635Z',
+        value: '2013-12-21T15:51:57.635Z'
+      };
+      
+      // Ex: "Sat Dec 21 2013 10:51:57 GMT-0500 (EST)", but exact value may vary slightly by platform.
+      var datestr = new Date('2013-12-21T15:51:57.635Z').toString();
+
+      expect(convert.v8RefToInspectorObject(ref).description).to.equal('Date: ' + datestr);
+    });
   });
 });


### PR DESCRIPTION
Proposed fix for issue #261.

This calls Date.toString and appends it to the description. This is similar to what Chrome does: https://bugs.webkit.org/show_bug.cgi?id=71605

Result:

![fix](https://f.cloud.github.com/assets/766698/1796579/556a3260-6a77-11e3-8f25-61897e80f1b7.png)
