### PR TITLE
Added large String support for console evaluation

### DIFF
--- a/lib/DebuggerClient.js
+++ b/lib/DebuggerClient.js
@@ -86,6 +86,8 @@ DebuggerClient.prototype.request = function(command, args, callback) {
     };
   }
 
+  args.maxStringLength = 10000;
+
   this._conn.request(command, { arguments: args }, function(response) {
     var refsLookup;
     if (!response.success)

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -135,7 +135,7 @@ exports.v8ResultToInspectorResult = function(result) {
   return {
     type: result.type,
     value: result.value,
-    description: String(result.text)
+    description: String(result.value)
   };
 };
 

--- a/test/DebuggerAgent.js
+++ b/test/DebuggerAgent.js
@@ -188,4 +188,38 @@ describe('DebuggerAgent', function() {
       done();
     });
   });
+
+  describe('canGetStringValuesLargerThan80Chars', function() {
+    before(setupDebugScenario);
+
+    it('returns large String values of 10000', function(done) {
+      var testExpression = "Array(10000).join('a');"
+      var expectedValue = Array(10000).join('a');
+
+      agent.evaluateOnCallFrame(
+        {
+          callFrameId: 0,
+          expression: testExpression
+        },
+        function(err, data) {
+          if (err) throw err;
+
+          expect(data.result.value)
+            .to.equal(expectedValue);
+
+          done();
+        }
+      );
+    });
+
+    var debuggerClient, agent;
+
+    function setupDebugScenario(done) {
+      launcher.runOnBreakInFunction(function(client) {
+        debuggerClient = client;
+        agent = new DebuggerAgent({}, null, debuggerClient, null, null);
+        done();
+      });
+    }
+  });
 });


### PR DESCRIPTION
Related to #29

Set the max string length to be 100k in evaluateOnCallFrame

Added a unit test "canGetStringValuesLargerThan80Chars" to check 100k strings are received from the debugger

Extracted shared code in to a function called v8ResultToInspectorResultLarge in lib/convert.js
