### PR TITLE
Fix issue #277 - DebuggerAgent.resume() success

### DIFF
--- a/lib/DebuggerClient.js
+++ b/lib/DebuggerClient.js
@@ -1,3 +1,4 @@
+var extend = require('util')._extend;
 var EventEmitter = require('events').EventEmitter,
   inherits = require('util').inherits,
   DebugConnection = require('./debugger.js');
@@ -86,7 +87,7 @@ DebuggerClient.prototype.request = function(command, args, callback) {
     };
   }
 
-  args.maxStringLength = 10000;
+  args = extend({ maxStringLength: 10000 }, args);
 
   this._conn.request(command, { arguments: args }, function(response) {
     var refsLookup;

--- a/test/DebuggerAgent.js
+++ b/test/DebuggerAgent.js
@@ -193,7 +193,7 @@ describe('DebuggerAgent', function() {
     before(setupDebugScenario);
 
     it('returns large String values of 10000', function(done) {
-      var testExpression = "Array(10000).join('a');"
+      var testExpression = "Array(10000).join('a');";
       var expectedValue = Array(10000).join('a');
 
       agent.evaluateOnCallFrame(
@@ -210,6 +210,27 @@ describe('DebuggerAgent', function() {
           done();
         }
       );
+    });
+
+    var debuggerClient, agent;
+
+    function setupDebugScenario(done) {
+      launcher.runOnBreakInFunction(function(client) {
+        debuggerClient = client;
+        agent = new DebuggerAgent({}, null, debuggerClient, null, null);
+        done();
+      });
+    }
+  });
+  
+  describe('canResumeScriptExecutionWithoutError', function() {
+    before(setupDebugScenario);
+
+    it('resumes without error', function(done) {
+      expect(function () { agent.resume(); })
+        .to.not.throw();
+        
+      done();
     });
 
     var debuggerClient, agent;


### PR DESCRIPTION
Related to #29 #272  #277 
<b>Reproduction:</b>

Using master 127955f6005c8cbd1c872d01e69149d54b9863ad
1. Set a breakpoint somewhere in the Sources section of the debugger client.
2. In the debugged application, do something that traverses the breakpoint
   --> AUT execution pauses, debugger client shows paused.
3. Open the console in the debugger client.
4. Click the button to resume execution.

<b>Result:</b>

Error / crash:

```
/usr/local/lib/node_modules/node-inspector/lib/DebuggerClient.js:89
  args.maxStringLength = 10000;
                       ^
TypeError: Cannot set property 'maxStringLength' of undefined
    at DebuggerClient.request (/usr/local/lib/node_modules/node-inspector/lib/DebuggerClient.js:90:24)
    at Object.DebuggerAgent._sendContinue (/usr/local/lib/node_modules/node-inspector/lib/DebuggerAgent.js:132:26)
  ...
```

:zap: : I'm not sure how / if the test should be updated.
