### PR TITLE
Reload browser when detached from target Fixes #266

### DIFF
--- a/front-end-node/Overrides.js
+++ b/front-end-node/Overrides.js
@@ -157,3 +157,11 @@ function getAllUiSourceCodes() {
 
   return uiSourceCodes;
 }
+
+var oldDetached = WebInspector.detached;
+WebInspector.detached = function () {
+  oldDetached.apply(this, arguments);
+  setTimeout(function () {
+    location.reload();
+  }, 100);
+};


### PR DESCRIPTION
This is a very simple solution to fix #266 and reload the browser when the inspected node script restarts. I am wondering if this should be an option in the cli otherwise it will do this every time node-inspector detaches. Any thoughts?
