### PR TITLE
Reload Inspector after detach. Issue #266

### DIFF
--- a/front-end-node/Overrides.js
+++ b/front-end-node/Overrides.js
@@ -22,7 +22,11 @@ function onWebSocketMessage(message) {
 
   if (message === 'showConsole') {
     WebInspector.showConsole();
-  } else {
+  } 
+  else if (message === 'reloadInspector') {
+    location.reload();
+  } 
+  else {
     InspectorBackend.dispatch(message);
   }
 }
@@ -121,7 +125,6 @@ WebInspector.notifications.addEventListener(
   },
   null
 );
-
 
 function showMainAppFile() {
   var fileTabs = WebInspector.showPanel('scripts')._editorContainer._files;

--- a/lib/DebuggerClient.js
+++ b/lib/DebuggerClient.js
@@ -3,12 +3,14 @@ var EventEmitter = require('events').EventEmitter,
   inherits = require('util').inherits,
   DebugConnection = require('./debugger.js');
 
-function createFailingConnection(reason) {
+function createFailingConnection(reason, type) {
+  var TypedError = exports[type];
+  
   return {
     isRunning: false,
 
     request: function(command, args, callback) {
-      callback({ message: new ErrorNotConnected(reason) });
+      callback({ message: new TypedError(reason) });
     },
 
     close: function() {
@@ -21,7 +23,8 @@ function createFailingConnection(reason) {
  * @param {number} debuggerPort
  */
 function DebuggerClient(debuggerPort) {
-  this._conn = createFailingConnection('node-inspector server was restarted');
+  var reason = 'node-inspector server was restarted';
+  this._conn = createFailingConnection(reason, 'ErrorNotConnected');
   this._port = debuggerPort;
 }
 
@@ -47,6 +50,16 @@ DebuggerClient.prototype.connect = function() {
   this._registerDebuggerEventHandlers('break', 'afterCompile', 'exception');
 };
 
+DebuggerClient.prototype.reconnect = function() {
+  setTimeout(function(){
+    this._conn = DebugConnection.attachDebugger(this._port);
+    
+    this._conn.
+      on('connect', this.emit.bind(this, 'reconnect')).
+      on('error', this.emit.bind(this, 'error')).
+      on('close', this._onConnectionClose.bind(this));
+  }.bind(this), 500);
+}
 
 /**
  * @param {...string} eventNames
@@ -62,7 +75,7 @@ DebuggerClient.prototype._registerDebuggerEventHandlers = function(eventNames) {
  * @param {string} reason
  */
 DebuggerClient.prototype._onConnectionClose = function(reason) {
-  this._conn = createFailingConnection(reason);
+  this._conn = createFailingConnection(reason, 'ErrorTargetCrashed');
   this.emit('close', reason);
 };
 
@@ -206,5 +219,18 @@ function ErrorNotConnected(message) {
 
 inherits(ErrorNotConnected, Error);
 
+/**
+ * @param {string} message
+ * @constructor
+ */
+function ErrorTargetCrashed(message) {
+  Error.call(this);
+  this.name = ErrorTargetCrashed.name;
+  this.message = message;
+}
+
+inherits(ErrorTargetCrashed, Error);
+
 exports.DebuggerClient = DebuggerClient;
 exports.ErrorNotConnected = ErrorNotConnected;
+exports.ErrorTargetCrashed = ErrorTargetCrashed;

--- a/lib/FrontendClient.js
+++ b/lib/FrontendClient.js
@@ -1,7 +1,8 @@
 var EventEmitter = require('events').EventEmitter,
     inherits = require('util').inherits,
     debugProtocol = require('debug')('node-inspector:protocol:devtools'),
-    ErrorNotConnected = require('./DebuggerClient').ErrorNotConnected;
+    ErrorNotConnected = require('./DebuggerClient').ErrorNotConnected,
+    ErrorTargetCrashed = require('./DebuggerClient').ErrorTargetCrashed;
 
 /**
  * FrontendClient encapsulates communication with front-end running in browser.
@@ -95,6 +96,10 @@ FrontendClient.prototype._onErrorResponse = function(fullMethodName, error) {
   if (error instanceof ErrorNotConnected) {
     this.sendInspectorDetached(error.message);
   }
+  else if (error instanceof ErrorTargetCrashed) {
+    this.sendInspectorTargetCrashed();
+  }
+  
   this.sendLogToConsole('error', fullMethodName + ' failed.\n' + error);
 };
 
@@ -142,6 +147,17 @@ FrontendClient.prototype.sendLogToConsole = function(level, text) {
  */
 FrontendClient.prototype.sendInspectorDetached = function(reason) {
   this.sendEvent('Inspector.detached', { reason: reason });
+};
+
+/**
+ * Shortcut for sendEvent('Inspector.targetCrashed')
+ */
+FrontendClient.prototype.sendInspectorTargetCrashed = function() {
+  this.sendEvent('Inspector.targetCrashed');
+};
+
+FrontendClient.prototype.sendReloadInspector = function(reason) {
+  this._sendMessage('reloadInspector');
 };
 
 exports.FrontendClient = FrontendClient;

--- a/lib/session.js
+++ b/lib/session.js
@@ -19,9 +19,15 @@ exports.create = function(debuggerPort, config) {
       breakEventHandler;
 
   function onDebuggerClientClose(reason) {
+    if (frontendClient.isConnected) {
+      frontendClient.sendInspectorTargetCrashed();
+      debuggerClient.reconnect();
+    }      
+  }
+  
+  function onDebuggerClientReconnect() {
     if (frontendClient.isConnected)
-      frontendClient.sendInspectorDetached(reason);
-    sessionInstance.close();
+      frontendClient.sendReloadInspector();
   }
 
   function onDebuggerClientError(e) {
@@ -69,6 +75,7 @@ exports.create = function(debuggerPort, config) {
         frontendClient.on('close', this.close.bind(this));
 
         debuggerClient.on('close', onDebuggerClientClose);
+        debuggerClient.on('reconnect', onDebuggerClientReconnect);
         debuggerClient.on('error', onDebuggerClientError);
       }
     }


### PR DESCRIPTION
Now, if app was closed, Inspector waits to reconnects.
Added new error type 'ErrorTargetCrashed'.
Added new frontend command 'reloadInspector'.
Realised frontend command 'targetCrashed'.