### PR TITLE
let node-inspector be hosted in a subfolder

### DIFF
--- a/front-end-node/Overrides.js
+++ b/front-end-node/Overrides.js
@@ -1,6 +1,14 @@
 // Wire up websocket to talk to backend
 WebInspector.loaded = function() {
-  WebInspector.socket = io.connect(window.location.protocol + "//" + window.location.host + '/');
+  var resolveRelativePath = function(url) {
+    var a = document.createElement('a');
+    a.href = url;
+    return a.pathname;
+  }
+
+  var ioHost = window.location.protocol + "//" + window.location.host + '/';
+  var ioResource = resolveRelativePath('socket.io').substr(1);
+  WebInspector.socket = io.connect(ioHost, {resource: ioResource});
   WebInspector.socket.on('message', onWebSocketMessage);
   WebInspector.socket.on('error', function(error) { console.error(error); });
   WebInspector.socket.on('connect', onWebSocketConnected);

--- a/front-end/inspector.html
+++ b/front-end/inspector.html
@@ -187,7 +187,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <script type="text/javascript" src="ScreencastView.js"></script>
     <script type="text/javascript" src="DevToolsExtensionAPI.js"></script>
     <script type="text/javascript" src="Tests.js"></script>
-    <script type="text/javascript" src="/socket.io/socket.io.js"></script>
+    <script type="text/javascript" src="socket.io/socket.io.js"></script>
     <script type="text/javascript" src="node/Overrides.js"></script>
 </head>
 <body class="detached" id="-webkit-web-inspector">


### PR DESCRIPTION
Allows hosting with a reverse-proxy, like Nginx, on any domain/subfolder/subfolder2 level.

Also, when the app in the main domain (http://example.com/) is already a socket.io app, node-inspector's socket.io, which was hardcoded to <domain>/socket.io/, used to conflict.
