### PR TITLE
Replacement of socket.io as the server-transport with websockets using WS 

### DIFF
--- a/front-end/inspector.html
+++ b/front-end/inspector.html
@@ -187,7 +187,6 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <script type="text/javascript" src="ScreencastView.js"></script>
     <script type="text/javascript" src="DevToolsExtensionAPI.js"></script>
     <script type="text/javascript" src="Tests.js"></script>
-    <script type="text/javascript" src="socket.io/socket.io.js"></script>
     <script type="text/javascript" src="node/Overrides.js"></script>
 </head>
 <body class="detached" id="-webkit-web-inspector">

--- a/lib/FrontendClient.js
+++ b/lib/FrontendClient.js
@@ -27,7 +27,7 @@ Object.defineProperties(FrontendClient.prototype, {
 });
 
 FrontendClient.prototype._registerEventHandlers = function() {
-  this._connection.on('disconnect', this._onConnectionClose.bind(this));
+  this._connection.on('close', this._onConnectionClose.bind(this));
   this._connection.on('message', this._onConnectionMessage.bind(this));
 };
 

--- a/lib/debug-server.js
+++ b/lib/debug-server.js
@@ -4,7 +4,7 @@ var http = require('http'),
     extend = require('util')._extend,
     path = require('path'),
     express = require('express'),
-    io = require('socket.io'),
+    WebSocketServer = require('ws').Server;
     Session = require('./session'),
     buildUrl = require('../index.js').buildInspectorUrl,
     WEBROOT = path.join(__dirname, '../front-end');
@@ -50,13 +50,12 @@ DebugServer.prototype.start = function(options) {
   app.get('/node/Overrides.js', overridesAction);
   app.use(express.static(WEBROOT));
 
-  var ws = io.listen(httpServer);
-  ws.configure(function() {
-    ws.set('transports', ['websocket']);
-    ws.set('log level', 1);
+  this.wsServer = new WebSocketServer({
+      server: httpServer
   });
-  ws.sockets.on('connection', handleWebSocketConnection.bind(this));
-  this.wsServer = ws;
+
+  this.wsServer.on('connection', handleWebSocketConnection.bind(this));
+
   httpServer.on('listening', handleServerListening.bind(this));
   httpServer.on('error', handleServerError.bind(this));
   httpServer.listen(this._config.webPort, this._config.webHost);

--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
     "node-inspector": "./bin/inspector.js"
   },
   "dependencies": {
-    "socket.io": "~0.9.14",
     "express": "~3.4",
     "async": "~0.2.8",
     "glob": "~3.2.1",
     "rc": "~0.3.0",
     "strong-data-uri": "~0.1.0",
-    "debug": "~0.7.3"
+    "debug": "~0.7.3",
+    "ws": "~0.4.31"
   },
   "devDependencies": {
     "mocha": "latest",


### PR DESCRIPTION
This is a replacement of socket.io as the server-transport with websockets using WS instead.

Should be fixing #290 and #274.
#### Consequences:
- Re-gained compatibility with Chrome DevTools.
-  Re-gained compatibility with current version of the RemoteDebug protocol.
#### Potential enhancements:
- There should probably be added a few tests to test the connection itself.
#### Tests:
- Tested in Chrome 32.
- All unit tests are passing. 
