### PR TITLE
Fix conversion of Error objects

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -68,11 +68,12 @@ exports.v8ScopeTypeToString = function(v8ScopeType) {
 
 exports.v8RefToInspectorObject = function(ref) {
   var desc = '',
+      type = ref.type,
       size,
       name,
       objectId;
 
-  switch (ref.type) {
+  switch (type) {
     case 'object':
       name = /#<(\w+)>/.exec(ref.text);
       if (name && name.length > 1) {
@@ -83,13 +84,17 @@ exports.v8RefToInspectorObject = function(ref) {
         }
       } else if (ref.className === 'Date') {
         desc = new Date(ref.value).toString();
-        ref.type = 'date';
+        type = 'date';
       } else {
         desc = ref.className || 'Object';
       }
       break;
     case 'function':
       desc = ref.text || 'function()';
+      break;
+    case 'error':
+      type = 'object';
+      desc = ref.text || 'Error';
       break;
     default:
       desc = ref.text || '';
@@ -104,7 +109,7 @@ exports.v8RefToInspectorObject = function(ref) {
     objectId = ref.ref;
 
   return {
-    type: ref.type,
+    type: type,
     objectId: String(objectId),
     className: ref.className,
     description: desc
@@ -123,7 +128,7 @@ exports.v8ErrorToInspectorError = function(message) {
 };
 
 exports.v8ResultToInspectorResult = function(result) {
-  if (['object', 'function', 'regexp'].indexOf(result.type) > -1) {
+  if (['object', 'function', 'regexp', 'error'].indexOf(result.type) > -1) {
     return exports.v8RefToInspectorObject(result);
   }
 

--- a/test/convert.js
+++ b/test/convert.js
@@ -179,5 +179,35 @@ describe('convert', function() {
       expect(converted.className).to.equal(ref.className);
       expect(converted.description).to.equal(ref.description);
     });
+
+    it('converts error as object', function() {
+      var v8Result = {
+        "handle": 6,
+        "type": "error",
+        "className": "Error",
+        "constructorFunction": {
+          "ref": 47
+        },
+        "protoObject": {
+          "ref": 48
+        },
+        "prototypeObject": {
+          "ref": 2
+        },
+        "properties": [
+          // stack, arguments, type, message
+        ],
+        "text": "Error: ENOENT, open 'missing-file'"
+      };
+
+      var converted = convert.v8ResultToInspectorResult(v8Result);
+
+      expect(converted).to.eql({
+        type: 'object',
+        objectId: '6',
+        className: 'Error',
+        description: v8Result.text
+      });
+    })
   });
 });


### PR DESCRIPTION
Convert V8 object with type='error' to DevTools object with
type='object'. This fixes the problem where Error values
were displayed as "undefined" in the front-end.

Close #299.
