### PR TITLE
Add WebSocketServer error handler.

### DIFF
--- a/lib/debug-server.js
+++ b/lib/debug-server.js
@@ -4,7 +4,7 @@ var http = require('http'),
     extend = require('util')._extend,
     path = require('path'),
     express = require('express'),
-    WebSocketServer = require('ws').Server;
+    WebSocketServer = require('ws').Server,
     Session = require('./session'),
     buildUrl = require('../index.js').buildInspectorUrl,
     WEBROOT = path.join(__dirname, '../front-end');
@@ -32,6 +32,8 @@ function handleServerListening() {
 }
 
 function handleServerError(err) {
+  if (err._handledByInspector) return;
+  err._handledByInspector = true;
   this.emit('error', err);
 }
 
@@ -51,10 +53,10 @@ DebugServer.prototype.start = function(options) {
   app.use(express.static(WEBROOT));
 
   this.wsServer = new WebSocketServer({
-      server: httpServer
+    server: httpServer
   });
-
   this.wsServer.on('connection', handleWebSocketConnection.bind(this));
+  this.wsServer.on('error', handleServerError.bind(this));
 
   httpServer.on('listening', handleServerListening.bind(this));
   httpServer.on('error', handleServerError.bind(this));


### PR DESCRIPTION
WebSocketServer emits the errors raised by the underlying http.Server,
thus we have to detect and prevent the situation when a single error
is reported twice.
