### PR TITLE
Implement `node-debug` script

### DIFF
--- a/bin/node-debug.js
+++ b/bin/node-debug.js
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+
+var fork = require('child_process').fork;
+var fs = require('fs');
+var path = require('path');
+var util = require('util');
+var open = require('opener');
+var yargs = require('yargs');
+var whichSync = require('which').sync;
+var inspector = require('..');
+
+var argvOptions = {
+  'debug-brk': {
+    alias: 'b',
+    default: true,
+    description: 'Breaks on the first line by default,' +
+      ' use --no-debug-brk to disable (call node --debug-brk)'
+  },
+  'web-port': {
+    alias: ['p', 'port'],
+    type: 'number',
+    description: 'The port where Node Inspector should listen on' +
+      ' (`node-inspector --web-port={port}`)'
+  },
+  'debug-port': {
+    alias: 'd',
+    type: 'number',
+    description: 'The port for the Node/V8 debugger (`node --debug={port}`)'
+  },
+  cli: {
+    alias: 'c',
+    type: 'boolean',
+    description: 'CLI mode, do not open browser.'
+  },
+  version: {
+    alias: 'v',
+    type: 'boolean',
+    description: 'Print Node Inspector\'s version.'
+  },
+  help: {
+    alias: 'h',
+    type: 'boolean',
+    description: 'Show this help.'
+  }
+};
+
+var argvParser = createYargs();
+
+module.exports = main;
+module.exports.parseArgs = parseArgs;
+
+if (require.main == module)
+  main();
+
+//-- Implementation --
+
+var config;
+
+/**
+ * By default:
+ *
+ * 1. Runs node-inspector.
+ * 2. Runs the supplied script in debug mode
+ * 3. Opens the user's browser, pointing it at the inspector.
+ *
+ * NOTE: Finishes with a call to process.exit() when running without arguments
+ * or when an error occured.
+ */
+function main() {
+  config = parseArgs(process.argv);
+  if (config.options.help) {
+    argvParser.showHelp(console.log);
+    console.log('The [script] argument is resolved relative to the current\n' +
+      'working directory. If no such file exists, then env.PATH is searched.\n');
+    console.log('When there is no script specified, the module in the current\n' +
+      'working directory is loaded in the REPL session as `m`. This allows you\n' +
+      'to call and debug arbitrary functions exported by the current module.\n');
+    process.exit();
+  }
+
+  if (config.options.version) {
+    console.log('v' + require('../package.json').version);
+    process.exit();
+  }
+
+  startInspector(function(err) {
+    if (err) {
+      console.error(formatNodeInspectorError(err));
+      process.exit(1);
+    }
+
+    startDebuggedProcess(function(err) {
+      if (err) {
+        console.error(
+          'Cannot start %s: %s',
+          config.subproc.script,
+          err.message || err
+        );
+        process.exit(2);
+      }
+
+      openBrowserAndPrintInfo();
+    });
+  });
+}
+
+function parseArgs(argv) {
+  argv = argv.slice(2);
+  var options = argvParser.parse(argv);
+  var script = options._[0];
+  var printScript = true;
+
+  var subprocArgs;
+
+  if (script) {
+    // We want to pass along subarguments, but re-parse our arguments.
+    subprocArgs = argv.splice(argv.indexOf(script) + 1);
+  } else {
+    script = require.resolve('./run-repl');
+    subprocArgs = [];
+    printScript = false;
+    process.env.CMD = process.env.CMD || process.argv[1];
+  }
+
+  options = argvParser.parse(argv);
+
+  var subprocPort = options['debug-port'] || 5858;
+  var subprocExecArgs = ['--debug=' + subprocPort];
+
+  if (options['debug-brk']) {
+    subprocExecArgs.push('--debug-brk');
+  }
+
+  var inspectorPort = options['web-port'] || 8080;
+  var inspectorArgs = extractPassThroughArgs(options, argvOptions)
+    .concat(['--web-port=' + inspectorPort]);
+
+  return {
+    printScript: printScript,
+    options: options,
+    subproc: {
+      script: script,
+      args: subprocArgs,
+      execArgs:  subprocExecArgs,
+      debugPort: subprocPort
+    },
+    inspector: {
+      port: inspectorPort,
+      args: inspectorArgs
+    }
+  };
+}
+
+function createYargs() {
+  var y = yargs
+    .options(argvOptions)
+    .usage('Usage:\n' +
+      '    $0 [node-inspector-options] [options] script [script-arguments]');
+  y.$0 = getCmd();
+  return y;
+}
+
+function getCmd() {
+  return process.env.CMD || process.argv[1];
+}
+
+function extractPassThroughArgs(options, argvOptions) {
+  var result = [];
+  var optionsToSkip = { _: true, $0: true };
+
+  // Skip options handled by node-debug
+  Object.keys(argvOptions).forEach(function(key) {
+    optionsToSkip[key] = true;
+    var alias = argvOptions[key].alias;
+    if (Array.isArray(alias)) {
+      alias.forEach(function(opt) { optionsToSkip[opt] = true; });
+    } else if (alias) {
+      optionsToSkip[alias] = true;
+    }
+  });
+
+  // Filter options not handled by node-debug
+  Object.keys(options).forEach(function(key) {
+    if (optionsToSkip[key]) return;
+    var value = options[key];
+    if (value === undefined) return;
+    if (value === true) {
+      result.push('--' + key);
+    } else if (value === true) {
+      result.push('--no-' + key);
+    } else {
+      result.push('--' + key);
+      result.push(value);
+    }
+  });
+
+  return result;
+}
+
+function startInspector(callback) {
+  var inspectorProcess = fork(
+    require.resolve('./inspector'),
+    config.inspector.args,
+    { silent: true }
+  );
+
+  inspectorProcess.once('message', function(msg) {
+    switch (msg.event) {
+    case 'SERVER.LISTENING':
+      return callback(null, msg.address);
+    case 'SERVER.ERROR':
+      return callback(msg.error);
+    default:
+      console.warn('Unknown Node Inspector event: %s', msg.event);
+      return callback(
+        null,
+        {
+          address: 'localhost',
+          port: config.inspector.port
+        }
+      );
+    }
+  });
+
+  process.on('exit', function() {
+    inspectorProcess.kill();
+  });
+}
+
+function formatNodeInspectorError(err) {
+  var reason = err.message || err.code || err;
+  if (err.code === 'EADDRINUSE') {
+    reason += '\nThere is another process already listening at 0.0.0.0:' +
+      config.inspector.port + '.\n' +
+      'Run `' + getCmd() + ' -p {port}` to use a different port.';
+  }
+
+  return util.format('Cannot start Node Inspector:', reason);
+}
+
+function startDebuggedProcess(callback) {
+  var script = path.resolve(process.cwd(), config.subproc.script);
+  if (!fs.existsSync(script)) {
+    try {
+      script = whichSync(config.subproc.script);
+    } catch (err) {
+      return  callback(err);
+    }
+  }
+
+  var debuggedProcess = fork(
+    script,
+    config.subproc.args,
+    {
+      execArgv: config.subproc.execArgs
+    }
+  );
+  debuggedProcess.on('exit', function() { process.exit(); });
+  callback();
+}
+
+function openBrowserAndPrintInfo() {
+  var url = inspector.buildInspectorUrl(
+    'localhost',
+    config.inspector.port,
+    config.subproc.debugPort
+  );
+
+  if (!config.options.cli) {
+    open(url);
+  }
+
+  console.log('Node Inspector is now available from %s', url);
+  if (config.printScript)
+    console.log('Debugging `%s`\n', config.subproc.script);
+}

--- a/bin/run-repl.js
+++ b/bin/run-repl.js
@@ -1,0 +1,81 @@
+// Load the module contained in the current directory (cwd) and start REPL
+// NOTE: Calls process.exit() after REPL was closed
+
+var Module = require('module');
+var path = require('path');
+var repl = require('repl');
+var util = require('util');
+
+var location = process.cwd();
+
+var moduleToDebug;
+var sampleLine;
+var prompt;
+
+try {
+  loadAndDescribeModuleInCwd();
+} catch (e) {
+  sampleLine = util.format(
+    'The module in the current directory was not loaded: %s.',
+    e.message || e
+  );
+}
+
+startRepl();
+
+//---- Implementation ----
+
+function loadAndDescribeModuleInCwd() {
+// Hack: Trick node into changing process.mainScript to moduleToDebug
+  moduleToDebug = Module._load(location, module, true);
+
+  var sample = getSampleCommand();
+  sampleLine = util.format('You can access your module as `m`%s.', sample);
+
+  prompt = getModuleName() + '> ';
+}
+
+function startRepl() {
+  var cmd = process.env.CMD || process.argv[1];
+
+  console.log(
+    '\nStarting the interactive shell (REPL). Type `.help` for help.\n' +
+      '%s\n' +
+      'Didn\'t want to start REPL? Run `%s .` instead.',
+    sampleLine,
+    cmd
+  );
+
+  var r = repl.start( { prompt: prompt });
+  if (moduleToDebug !== undefined)
+    r.context.m = moduleToDebug;
+  r.on('exit', onReplExit);
+}
+
+function onReplExit() {
+  console.log('\nLeaving the interactive shell (REPL).');
+  process.exit();
+}
+
+function getModuleName() {
+  try {
+    var packageJson = require(path.join(location, 'package.json'));
+    if (packageJson.name)
+      return packageJson.name;
+  } catch (e) {
+    // ignore missing package.json
+  }
+
+  return path.basename(location);
+}
+
+function getSampleCommand() {
+  var exportedSymbols = Object.keys(moduleToDebug);
+  if (!exportedSymbols.length) return '';
+
+  var sample = exportedSymbols[0];
+  if (typeof(moduleToDebug[sample]) === 'function')
+    sample += '()';
+
+  return ', e.g. `m.' + sample + '`';
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "node": ">=0.8.0"
   },
   "bin": {
-    "node-inspector": "./bin/inspector.js"
+    "node-inspector": "./bin/inspector.js",
+    "node-debug": "./bin/node-debug.js"
   },
   "dependencies": {
     "express": "~3.4",
@@ -27,7 +28,10 @@
     "rc": "~0.3.0",
     "strong-data-uri": "~0.1.0",
     "debug": "~0.7.3",
-    "ws": "~0.4.31"
+    "ws": "~0.4.31",
+    "opener": "~1.3.0",
+    "yargs": "~1.1.2",
+    "which": "~1.0.5"
   },
   "devDependencies": {
     "mocha": "latest",

--- a/test/node-debug.test.js
+++ b/test/node-debug.test.js
@@ -1,0 +1,87 @@
+var cli = require('../bin/node-debug');
+var expect = require('chai').expect;
+
+describe('node-debug', function() {
+  describe('argument parser', function() {
+    it('handles `app.js`', function() {
+      var config = cli.parseArgs(argv('app.js'));
+      delete config.options;
+      expect(config).to.eql({
+        printScript: true,
+        subproc: {
+          script: 'app.js',
+          args: [],
+          execArgs: ['--debug=5858', '--debug-brk'],
+          debugPort: 5858
+        },
+        inspector: {
+          port: 8080,
+          args: ['--web-port=8080']
+        }
+      });
+    });
+
+    it('handles empty arguments', function() {
+      var config = cli.parseArgs(argv());
+      expect(config.printScript, 'printScript').to.equal(false);
+      expect(config.subproc.script, 'subproc.script')
+        .to.eql(require.resolve('../bin/run-repl'));
+    });
+
+    it('handles options', function () {
+      var config = cli.parseArgs(argv('--no-debug-brk -p 10 -d 20 -c app.js'));
+      expect(config.subproc).to.eql({
+        script: 'app.js',
+        args: [],
+        execArgs: ['--debug=20'],
+        debugPort: 20
+      });
+      expect(config.inspector).to.eql({
+        port: 10,
+        args: ['--web-port=10']
+      });
+    });
+
+    it('handles long options with =val and no script file', function () {
+      var config = cli.parseArgs(argv('--debug-port=10'));
+      expect(config.subproc.debugPort).to.equal(10);
+    });
+
+    it('ignores options of the debugged application', function() {
+      var config = cli.parseArgs(argv('app.js -b -p 10 -d 20 -c carg rest'));
+      expect(config.subproc).to.eql({
+        script: 'app.js',
+        args: '-b -p 10 -d 20 -c carg rest'.split(' '),
+        execArgs: ['--debug=5858', '--debug-brk'],
+        debugPort: 5858
+      });
+      expect(config.inspector.port, 'inspector.port').to.eql(8080);
+    });
+
+    it('supports slc-debug argument names', function() {
+      var config = cli.parseArgs(argv('--suspend --port=10 --debug-port=20'));
+      expect(config.subproc.execArgs).to.contain('--debug-brk');
+      expect(config.subproc.debugPort, 'subproc.debugPort').to.equal(20);
+      expect(config.inspector.port, 'inspector.port').to.equal(10);
+    });
+
+    it('supports node-inspector argument names', function () {
+      var config = cli.parseArgs(argv('--web-port=10 --debug-port=20 app.js'));
+      expect(config.subproc.debugPort, 'subproc.debugPort').to.equal(20);
+      expect(config.inspector.port, 'inspector.port').to.equal(10);
+    });
+
+    it('forwards unknown options to node-inspector', function () {
+      var config = cli.parseArgs(argv('--some-bool --some-string val app.js'));
+      expect(config.inspector.args, 'inspector args')
+        .to.eql(['--some-bool', '--some-string', 'val', '--web-port=8080']);
+      expect(config.subproc.execArgs, 'subprocess args')
+        .to.not.include.members(['--some-bool','--some-string', 'val']);
+    });
+
+    function argv(cmdString) {
+      cmdString = cmdString || '';
+      return ['node', 'node-debug'].concat(cmdString.split(' '));
+    }
+  });
+});


### PR DESCRIPTION
Add a CLI script `node-debug` that:
1. Runs node-inspector.
2. Runs the supplied script in debug mode or starts a REPL session
3. Opens the user's browser, pointing it at the inspector.

Add a CLI script `run-repl` (used by `node-debug`) that will load
the module in CWD and start a REPL session.

The script `node-debug` is friendly to embedders, error messages use the value of the env variable "CMD" when referring to $0.

/to: @sam-github please review. I'll submit the documentation changes in a standalone pull request.

The file node-debug.js is based on [strong-cli/lib/commands/debug.js](https://github.com/strongloop/strong-cli/blob/master/lib/commands/debug.js). The most notable difference is the naming of command-line arguments. I have decided to use the names that are already used by Node and Node Inspector (e.g. `--web-port` instead of `--port`, `--debug-brk` instead of `--suspend`). I have added aliases to keep backwards compatibility with `slc debug`.

/cc: @sidorares @Krxtopher @jfirebaugh
The script `node-debug` added by this pull request is replacing your modules [ni](https://github.com/sidorares/ni), [node-ndebug](https://github.com/resource/node-ndebug) and [node-debug](https://github.com/jfirebaugh/node-debug). Is there any feature that is implemented in your module and missing in node-inspector's node-debug?
