### PR TITLE
bin/inspector: Add -h -v --version options

### DIFF
--- a/bin/inspector.js
+++ b/bin/inspector.js
@@ -7,6 +7,20 @@ var DebugServer = require('../lib/debug-server').DebugServer,
     packageJson = require('../package.json'),
     notifyParentProcess = getNotifyParentProcessFn();
 
+if (config.help || config.h) {
+  console.log('Usage:');
+  console.log('    node-inspector [options]');
+  console.log('\nOptions:');
+  console.log(config._describeOptions());
+  console.log();
+  process.exit();
+}
+
+if (config.version || config.v) {
+  console.log('v' + require('../package.json').version);
+  process.exit();
+}
+
 console.log('Node Inspector v%s', packageJson.version);
 
 var debugServer = new DebugServer();

--- a/lib/config.js
+++ b/lib/config.js
@@ -37,33 +37,6 @@ var conversions = {
     });
     return options;
   },
-  printHelpAndExit: function(value) {
-    if (value) {
-      var message = 'Usage: node-inspector [options]\nOptions:\n';
-
-      Object.keys(definitions).forEach(function constructMessagePart(key) {
-        var definition = definitions[key],
-            defaultValue = definition.defaultValue,
-            typeString = Object.prototype.toString.call(defaultValue),
-            defaultString = JSON.stringify(definition.defaultValue),
-            matchedType = /^\[object (.*)\]$/.exec(typeString)[1],
-            optionKey = '\u001b[92m--' + key,
-            optionTypeAndDefault =
-              matchedType !== 'Undefined' && matchedType !== 'Boolean' ?
-                '=\u001b[90m{' + matchedType + '}' +
-                ' \u001b[96m(default: ' + defaultString + ')' :
-                '',
-            optionDescription = '\u001b[0m' + definition.desc;
-
-        message += optionKey + optionTypeAndDefault + '\n' +
-                   optionDescription + '\n\n';
-      });
-
-      console.log(message);
-      process.exit();
-    }
-    return value;
-  },
   stringToArray: function(value) {
     var hidden;
     if (typeof value === 'string') {
@@ -90,8 +63,13 @@ var conversions = {
 };
 var definitions = {
   'help': {
-    desc: 'Print information about options and exit',
-    convert: conversions.printHelpAndExit,
+    desc: 'Show this help',
+    convert: conversions.stringToBoolean,
+    defaultValue: false
+  },
+  'version': {
+    desc: 'Print Node Inspector\'s version',
+    convert: conversions.stringToBoolean,
     defaultValue: false
   },
   'web-port': {
@@ -143,6 +121,31 @@ config.isScriptHidden = function(scriptPath) {
 };
 
 module.exports = config;
+
+module.exports._describeOptions = function() {
+  return Object.keys(definitions)
+    .map(function constructMessagePart(key) {
+      var definition = definitions[key];
+
+      var defaultValue = definition.defaultValue;
+      var defaultString = JSON.stringify(definition.defaultValue);
+
+      var typeString = Object.prototype.toString.call(defaultValue);
+      var matchedType = /^\[object (.*)\]$/.exec(typeString)[1];
+
+      var optionKey = '\u001b[92m--' + key;
+      var optionTypeAndDefault =
+        matchedType !== 'Undefined' && matchedType !== 'Boolean' ?
+          '=\u001b[90m{' + matchedType + '}' +
+            ' \u001b[96m(default: ' + defaultString + ')' :
+          '';
+      var optionDescription = '\u001b[0m' + definition.desc;
+
+      return '    ' + optionKey + optionTypeAndDefault +
+        '\n    ' + optionDescription;
+    })
+    .join('\n\n');
+};
 
 function collectDefaultsFromDefinitions() {
   var options = {};


### PR DESCRIPTION
Refactor lib/config and bin/inspector, split printHelpAndExit into
two parts. The first part is building the help message and stays in
lib/config as `config._describeOptions`. The second part (print and
exit) is moved to bin/inspector.

/to @sam-github Please review. Node Inspector uses "rc" for argv parsing, therefore we can't use optimist's "alias".
/cc @3y3
