### PR TITLE
Clean up node-debug help message

### DIFF
--- a/bin/node-debug.js
+++ b/bin/node-debug.js
@@ -13,19 +13,17 @@ var argvOptions = {
   'debug-brk': {
     alias: 'b',
     default: true,
-    description: 'Breaks on the first line by default,' +
-      ' use --no-debug-brk to disable (call node --debug-brk)'
+    description: 'Break on the first line (`node --debug-brk`)'
   },
   'web-port': {
     alias: ['p', 'port'],
     type: 'number',
-    description: 'The port where Node Inspector should listen on' +
-      ' (`node-inspector --web-port={port}`)'
+    description: 'Node Inspector port (`node-inspector --web-port={port}`)'
   },
   'debug-port': {
     alias: 'd',
     type: 'number',
-    description: 'The port for the Node/V8 debugger (`node --debug={port}`)'
+    description: 'Node/V8 debugger port (`node --debug={port}`)'
   },
   cli: {
     alias: 'c',
@@ -70,11 +68,13 @@ function main() {
   config = parseArgs(process.argv);
   if (config.options.help) {
     argvParser.showHelp(console.log);
-    console.log('The [script] argument is resolved relative to the current\n' +
-      'working directory. If no such file exists, then env.PATH is searched.\n');
-    console.log('When there is no script specified, the module in the current\n' +
-      'working directory is loaded in the REPL session as `m`. This allows you\n' +
-      'to call and debug arbitrary functions exported by the current module.\n');
+    console.log('The [script] argument is resolved relative to the current working\n' +
+      'directory. If no such file exists, then env.PATH is searched.\n');
+    console.log('The default mode is to break on the first line of the script, to run\n' +
+      'immediately on start use `--no-debug-brk` or press the Resume button.\n');
+    console.log('When there is no script specified, the module in the current working\n' +
+      'directory is loaded in the REPL session as `m`. This allows you to call\n' +
+      'and debug arbitrary functions exported by the current module.\n');
     process.exit();
   }
 
@@ -161,7 +161,7 @@ function createYargs() {
 }
 
 function getCmd() {
-  return process.env.CMD || process.argv[1];
+  return process.env.CMD || path.basename(process.argv[1]);
 }
 
 function extractPassThroughArgs(options, argvOptions) {


### PR DESCRIPTION
- Reword so lines are closer to 80 chars wide (yargs does not wrap
  option descriptions).
- Use basename of $0 as command name, so full path
  (/usr/local/bin/node-debug) isn't printed in the usage.

Note that this syntax does not work:

```
node-debug --debug-brk script.js
```

This is basically a design error in optimist. The author assumes its possible to parse argv with no configuration, this is wrong. You need to know difference between flags (no argument) and options (have argument). In above, script.js is assumed to be argument to --debug-brk, so node-debug just does a require(.) and starts a repl.

In one case, luckily, optimist knows a flag is a flag: --no-debug-brk is treated as identical to --debug-brk=false, so the typical usage (now that debug brk is default), DOES work.
