### PR TITLE
Defer "scriptParsed" until "Page.getResourceTree"

### DIFF
--- a/lib/DebuggerAgent.js
+++ b/lib/DebuggerAgent.js
@@ -33,15 +33,17 @@ DebuggerAgent.prototype = {
   },
 
   enable: function(params, done) {
-    this._debuggerClient.on(
-      'connect',
-      function() {
-        done();
-        this._onDebuggerConnect();
-      }.bind(this)
-    );
+    var onConnect = function() {
+      done();
+      this._onDebuggerConnect();
+    }.bind(this);
 
-    this._debuggerClient.connect();
+    if (this._debuggerClient.isConnected) {
+      process.nextTick(onConnect);
+    } else {
+      this._debuggerClient.on('connect', onConnect);
+      this._debuggerClient.connect();
+    }
   },
 
   _onDebuggerConnect: function() {

--- a/lib/DebuggerClient.js
+++ b/lib/DebuggerClient.js
@@ -5,6 +5,7 @@ var EventEmitter = require('events').EventEmitter,
 
 function createFailingConnection(reason) {
   return {
+    connected: false,
     isRunning: false,
 
     request: function(command, args, callback) {
@@ -32,6 +33,12 @@ Object.defineProperties(DebuggerClient.prototype, {
   isRunning: {
     get: function() {
       return this._conn.isRunning;
+    }
+  },
+
+  isConnected: {
+    get: function() {
+      return this._conn.connected;
     }
   }
 });

--- a/lib/FrontendClient.js
+++ b/lib/FrontendClient.js
@@ -108,7 +108,32 @@ FrontendClient.prototype.sendEvent = function(eventName, data) {
     method: eventName,
     params: data || {}
   };
-  this._sendMessage(message);
+  if (this._eventsPaused) {
+    this._eventsBuffer.push(message);
+  } else {
+    this._sendMessage(message);
+  }
+};
+
+FrontendClient.prototype.pauseEvents = function() {
+  if (this._eventsPaused) return;
+  this._eventsPaused = true;
+  this._eventsBuffer = [];
+};
+
+FrontendClient.prototype.resumeEvents = function() {
+  if (!this._eventsPaused) return;
+
+  // We are making a copy of the buffered messages list,
+  // so that the messages are sent event when pauseEvents()
+  // is called before the next tick.
+  var messages = this._eventsBuffer;
+  process.nextTick(function() {
+    messages.forEach(this._sendMessage, this);
+  }.bind(this));
+
+  this._eventsPaused = false;
+  this._eventsBuffer = null;
 };
 
 /**

--- a/lib/FrontendCommandHandler.js
+++ b/lib/FrontendCommandHandler.js
@@ -26,6 +26,7 @@ function FrontendCommandHandler(config,
   this._scriptManager = scriptManager;
   this._initializeRegistry();
   this._registerEventHandlers();
+  this._pauseInitialEvents();
 }
 
 FrontendCommandHandler.prototype = {
@@ -104,6 +105,13 @@ FrontendCommandHandler.prototype = {
     debugProtocol('frontend: ' + message);
     var command = JSON.parse(message);
     this.handleCommand(command);
+  },
+
+  _pauseInitialEvents: function() {
+    this._frontendClient.pauseEvents();
+    this._agents.Page.on('resource-tree', function() {
+      this._frontendClient.resumeEvents();
+    }.bind(this));
   },
 
   handleCommand: function(messageObject) {

--- a/lib/PageAgent.js
+++ b/lib/PageAgent.js
@@ -1,6 +1,9 @@
 // node-inspector version of on webkit-inspector/InspectorPageAgent.cpp
 var fs = require('fs'),
   path = require('path'),
+  inherits = require('util').inherits,
+  extend = require('util')._extend,
+  EventEmitter = require('events').EventEmitter,
   async = require('async'),
   convert = require('./convert.js'),
   ScriptFileStorage = require('./ScriptFileStorage.js').ScriptFileStorage;
@@ -18,7 +21,9 @@ function PageAgent(config, debuggerClient, scriptManager) {
   this._scriptStorage = new ScriptFileStorage(config);
 }
 
-PageAgent.prototype = {
+inherits(PageAgent, EventEmitter);
+
+extend(PageAgent.prototype, {
   enable: function(params, done) {
     done();
   },
@@ -36,12 +41,17 @@ PageAgent.prototype = {
   },
 
   getResourceTree: function(params, done) {
-    if (this._debuggerClient.isRunning) {
-      this._doGetResourceTree(params, done);
+    var cb = function() {
+      done.apply(null, arguments);
+      this.emit('resource-tree');
+    }.bind(this);
+
+    if (this._debuggerClient.isConnected) {
+      this._doGetResourceTree(params, cb);
     } else {
       this._debuggerClient.once(
         'connect',
-        this._doGetResourceTree.bind(this, params, done)
+        this._doGetResourceTree.bind(this, params, cb)
       );
     }
   },
@@ -158,7 +168,7 @@ PageAgent.prototype = {
     // This is called when user press Cmd+R (F5?), do we want to perform an action on this?
     done();
   }
-};
+});
 
 exports.PageAgent = PageAgent;
 

--- a/test/FrontendCommandHandler.test.js
+++ b/test/FrontendCommandHandler.test.js
@@ -1,0 +1,90 @@
+var async = require('async');
+var expect = require('chai').expect;
+var launcher = require('./helpers/launcher.js');
+var FrontendCommandHandler = require('../lib/FrontendCommandHandler.js').FrontendCommandHandler;
+var FrontendClient = require('../lib/FrontendClient.js').FrontendClient;
+var ScriptFileStorage = require('../lib/ScriptFileStorage.js').ScriptFileStorage;
+var ScriptManager = require('../lib/ScriptManager.js').ScriptManager;
+var WebSocketMock = require('./helpers/wsmock');
+
+describe('FrontendCommandHandler', function() {
+  after(launcher.stopAllDebuggers);
+
+  it('defers "scriptParsed" events until "Page.getResourceTree"', function(done) {
+    var TREE_REQID = 10;
+
+    async.waterfall([
+      function startDebugger(cb) {
+        var scriptToDebug = 'BreakInFunction.js'; // any script will work
+        launcher.startDebugger(
+          scriptToDebug,
+          function(childProcess, debuggerClient) {
+            cb(null, debuggerClient);
+          });
+      },
+
+      function arrange(debuggerClient, cb) {
+        this.wsmock = new WebSocketMock();
+
+        var handler = createFrontendCommandHandler(this.wsmock, debuggerClient);
+        this.handler = handler;
+        this.handleCommand = function(req) {
+          handler.handleCommand(req);
+        };
+
+        cb();
+      },
+
+      function act(cb) {
+        this.handleCommand({ id: 1, method: 'Debugger.enable' });
+
+        // Introduce a small timeout to let DebuggerAgent fetch scripts
+        setTimeout(function() {
+          this.handleCommand({ id: TREE_REQID, method: 'Page.getResourceTree' });
+        }.bind(this), 100);
+
+        this.wsmock.on('send', function(payload) {
+          if (payload.id == TREE_REQID)
+            cb();
+        });
+      },
+
+      function verify(cb) {
+        var events = [];
+        this.wsmock.messages.forEach(function(msg) {
+          if (msg.id == TREE_REQID) {
+            events.push('resources');
+          } else if (msg.method == 'Debugger.scriptParsed') {
+            if (events.indexOf('scripts') == -1)
+              events.push('scripts');
+          }
+        });
+
+        expect(events).to.eql(['resources', 'scripts']);
+        cb();
+      }
+    ], done);
+  });
+
+  function createFrontendCommandHandler(wsclient, debuggerClient) {
+    var config = {
+      isHidden: function() { return false; }
+    };
+
+    var frontendClient = new FrontendClient(wsclient);
+
+    var scriptManager = new ScriptManager(
+      config.isHidden,
+      frontendClient,
+      debuggerClient);
+
+    var breakEventHandlerMock = {};
+
+    return new FrontendCommandHandler(
+      config,
+      frontendClient,
+      debuggerClient,
+      breakEventHandlerMock,
+      scriptManager);
+  }
+});

--- a/test/helpers/wsmock.js
+++ b/test/helpers/wsmock.js
@@ -1,0 +1,21 @@
+var inherits = require('util').inherits;
+var EventEmitter = require('events').EventEmitter;
+
+module.exports = WebSocketMock;
+
+function WebSocketMock() {
+  this.messages = [];
+}
+
+inherits(WebSocketMock, EventEmitter);
+
+WebSocketMock.prototype.send = function(payload) {
+  try {
+    payload = JSON.parse(payload);
+  } catch (e) {
+    // no-op, use the original string
+  }
+
+  this.messages.push(payload);
+  this.emit('send', payload);
+};


### PR DESCRIPTION
DevTools front-end expects to receive Page.getResourceTree response
before any "scriptParsed" events. When "scriptParsed" arrives first,
the source-map handler throws an exception.

Add FrontendClient methods pauseEvents() and resumeEvents().

Change PageAgent to EventEmitter, add a "resource-tree" event that
is emitted at the time when the Page.getResourceTree response is sent.

FrontendCommandHandler uses these two features to pause events on start
and resume them on "resource-tree".

Close #271.

/to @3y3 could you please review?
