### PR TITLE
Implement Debugger.setSkipAllPauses

### DIFF
--- a/lib/DebuggerAgent.js
+++ b/lib/DebuggerAgent.js
@@ -441,6 +441,13 @@ DebuggerAgent.prototype = {
         done(err, result);
       }
     );
+  },
+
+  setSkipAllPauses: function(params, done) {
+    if (params.skipped)
+      done(new Error('Not implemented.'));
+    else
+      done();
   }
 };
 


### PR DESCRIPTION
Implement the action as no-op for skipped=false. This argument value
is sent by the front-end when pausing program execution.
