### PR TITLE
Handle shebang in ScriptFileStorage load/save

### DIFF
--- a/lib/ScriptFileStorage.js
+++ b/lib/ScriptFileStorage.js
@@ -37,9 +37,18 @@ $class.save = function(path, content, callback) {
     return;
   }
   var newSource = match[1];
-  fs.writeFile(path, newSource, function(err) {
-    callback(err);
-  });
+  async.waterfall([
+    fs.readFile.bind(fs, path, 'utf-8'),
+
+    function(oldContent, cb) {
+      var match = /^(\#\!.*)/.exec(oldContent);
+      if (match)
+        newSource = match[1] + newSource;
+
+      fs.writeFile(path, newSource, cb);
+    }
+  ],
+  callback);
 };
 
 /**
@@ -52,6 +61,10 @@ $class.load = function(path, callback) {
     { encoding: 'utf-8' },
     function(err, content) {
       if (err) return callback(err);
+
+      // remove shebang
+      content = content.replace(/^\#\!.*/, '');
+
       var source = MODULE_HEADER + content + MODULE_TRAILER;
       return callback(null, source);
     }


### PR DESCRIPTION
Before this change, ScriptFileStorage.load was returning source code
including shebang (#!/usr/bin/node). This prevented the front-end
from matching the file on disk with the script loaded in Node/V8.
As a result, `node-debug _mocha` did not show the breakpoint in
the _mocha file.

ScriptFileStorage.save is preserving shebang when saving the updated
file now, so that live edit works as expected.

@3y3 could you please review?
