### PR TITLE
Use jshint instead of gjslint

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,2 @@
+node_modules
+/front-end

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,20 @@
+{
+"node": true,
+"eqnull" : true,
+"indent": 2,
+"undef": true,
+"quotmark": "single",
+"maxlen": 105,
+"trailing": true,
+"newcap": true,
+"nonew": true,
+"sub": true,
+"globals": {
+  "describe": true,
+  "it": true,
+  "before": true,
+  "beforeEach": true,
+  "after": true,
+  "afterEach": true
+}
+}

--- a/front-end-node/Overrides.js
+++ b/front-end-node/Overrides.js
@@ -1,3 +1,7 @@
+/*jshint browser:true */
+/*global WebInspector:true, InspectorFrontendHost:true, InspectorBackend:true, importScript:true */
+/*global Preferences:true */
+
 // Wire up websocket to talk to backend
 WebInspector.loaded = function() {
 
@@ -19,7 +23,7 @@ WebInspector.loaded = function() {
 var _inspectorInitialized = false;
 
 function onWebSocketError(error) {
-    console.error(error);
+  console.error(error);
 }
 
 function onWebSocketConnected() {
@@ -61,7 +65,7 @@ WebInspector._panelDescriptors = function() {
 // Patch the expression used as an initial value for a new watch.
 // DevTools' value "\n" breaks the debugger protocol.
 importScript('WatchExpressionsSidebarPane.js');
-WebInspector.WatchExpressionsSection.NewWatchExpression = "''";
+WebInspector.WatchExpressionsSection.NewWatchExpression = '\'\'';
 
 Preferences.localizeUI = false;
 Preferences.applicationTitle = 'Node Inspector';
@@ -169,11 +173,15 @@ function getAllUiSourceCodes() {
   for (var i = 0; i < projects.length; ++i) {
     projectFiles = projects[i]
       .uiSourceCodes()
-      .filter(function(p) { return p.name(); });
+      .filter(nameIsNotEmpty);
     uiSourceCodes = uiSourceCodes.concat(projectFiles);
   }
 
   return uiSourceCodes;
+
+  function nameIsNotEmpty(p) {
+    return p.name();
+  }
 }
 
 var oldDetached = WebInspector.detached;

--- a/lib/CallFramesProvider.js
+++ b/lib/CallFramesProvider.js
@@ -43,15 +43,15 @@ CallFramesProvider.prototype = {
 
   _convertDebuggerFrameToInspectorFrame: function(backtrackResponseRefs, frame, done) {
     var scopeChain = frame.scopes.map(function(scope) {
-       return {
-         object: {
-           type: 'object',
-           objectId: 'scope:' + frame.index + ':' + scope.index,
-           className: 'Object',
-           description: 'Object'
-         },
-         type: convert.v8ScopeTypeToString(scope.type)
-       };
+      return {
+        object: {
+          type: 'object',
+          objectId: 'scope:' + frame.index + ':' + scope.index,
+          className: 'Object',
+          description: 'Object'
+        },
+        type: convert.v8ScopeTypeToString(scope.type)
+      };
     });
 
     done(null, {

--- a/lib/RuntimeAgent.js
+++ b/lib/RuntimeAgent.js
@@ -85,9 +85,9 @@ RuntimeAgent.prototype = {
   _buildEvaluateParamsFromArgsData: function(selfId, declaration, argsData) {
     argsData.unshift(this._getSelfArgData(selfId));
 
-    var argNames = argsData.map(function(a) { return a.code });
+    var argNames = argsData.map(function(a) { return a.code; });
     var argContexts = argsData
-      .map(function(a) { return a.context })
+      .map(function(a) { return a.context; })
       // filter out empty contexts (value types are context-less)
       .filter(function(c) { return !!c; });
 
@@ -120,14 +120,11 @@ RuntimeAgent.prototype = {
       case undefined:
       case 'string':
         return { code: util.format('"%s"', arg.value) };
-        break;
       case 'number':
         return { code: arg.value };
-        break;
       case 'null':
       case 'undefined':
         return { code: arg.type };
-        break;
       case 'object':
       case 'function':
         return {
@@ -137,7 +134,6 @@ RuntimeAgent.prototype = {
             handle: Number(arg.objectId)
           }
         };
-        break;
       default:
         throw new Error(util.format(
           'Function arguments of type "%s" are not supported',

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -138,14 +138,14 @@ exports.v8ObjectToInspectorProperties = function(obj, refs, options) {
       accessorPropertiesOnly = options.accessorPropertiesOnly;
 
   props = props.map(function(prop) {
-    var ref = refs[prop.ref],
-        inspectorProperty = {
-          name: String(prop.name),
-          writable: !(prop.attributes & 1 << 0),
-          enumerable: !(prop.attributes & 1 << 1),
-          configurable: !(prop.attributes & 1 << 2),
-          value: exports.v8ResultToInspectorResult(ref)
-        };
+    var ref = refs[prop.ref];
+    var inspectorProperty = {
+        name: String(prop.name),
+        writable: !(prop.attributes & 1 << 0),
+        enumerable: !(prop.attributes & 1 << 1),
+        configurable: !(prop.attributes & 1 << 2),
+        value: exports.v8ResultToInspectorResult(ref)
+      };
     return inspectorProperty;
   });
 

--- a/lib/debugger.js
+++ b/lib/debugger.js
@@ -1,7 +1,7 @@
 var Net = require('net'),
     EventEmitter = require('events').EventEmitter,
     Buffer = require('buffer').Buffer,
-    debugProtocol = require('debug')('node-inspector:protocol:v8-debug');
+    debugProtocol = require('debug')('node-inspector:protocol:v8-debug'),
     callbackHandler = require('./callback').create();
 
 function makeMessage() {
@@ -95,10 +95,10 @@ exports.attachDebugger = function(port) {
     request: {
       value: function(command, params, callback) {
         var msg = {
-                   seq: 0,
-                   type: 'request',
-                   command: command
-                  };
+          seq: 0,
+          type: 'request',
+          command: command
+        };
         if (typeof callback == 'function') {
           msg.seq = callbackHandler.wrap(callback);
         }

--- a/lib/session.js
+++ b/lib/session.js
@@ -42,8 +42,8 @@ exports.create = function(debuggerPort, config) {
     },
 
     join: {
-      value: function(ws_connection) {
-        frontendClient = new FrontendClient(ws_connection);
+      value: function(wsConnection) {
+        frontendClient = new FrontendClient(wsConnection);
         debuggerClient = new DebuggerClient(debuggerPort);
 
         scriptManager = new ScriptManager(

--- a/package.json
+++ b/package.json
@@ -36,11 +36,12 @@
   "devDependencies": {
     "mocha": "latest",
     "chai": "latest",
+    "jshint": "^2.4.4",
     "fs-extra": "~0.8.1"
   },
   "preferGlobal": true,
   "scripts": {
-    "test": "mocha",
-    "lint": "./tools/gjslint.sh"
+    "pretest": "jshint .",
+    "test": "mocha"
   }
 }

--- a/test/CallFramesProvider.js
+++ b/test/CallFramesProvider.js
@@ -21,18 +21,18 @@ describe('CallFramesProvider', function() {
         expect(callFrames).to.have.length.least(2);
 
         function objectValueWithId(id, className) {
-         return {
-           type: 'object',
-           objectId: id,
-           className: className || 'Object',
-           description: className || 'Object'
-         };
+          return {
+            type: 'object',
+            objectId: id,
+            className: className || 'Object',
+            description: className || 'Object'
+          };
         }
 
         assertFrame({
             callFrameId: '0',
             functionName: 'MyObj.myFunc',
-            location: {scriptId: scriptId, lineNumber: 7, columnNumber: 4},
+            location: {scriptId: scriptId, lineNumber: 8, columnNumber: 4},
             scopeChain: [
               { object: objectValueWithId('scope:0:0'), type: 'local' },
               { object: objectValueWithId('scope:0:1'), type: 'closure' },
@@ -46,7 +46,7 @@ describe('CallFramesProvider', function() {
         assertFrame({
             callFrameId: '1',
             functionName: 'globalFunc',
-            location: {scriptId: scriptId, lineNumber: 12, columnNumber: 6},
+            location: {scriptId: scriptId, lineNumber: 13, columnNumber: 6},
             scopeChain: [
               { object: objectValueWithId('scope:1:0'), type: 'local' },
               { object: objectValueWithId('scope:1:1'), type: 'closure' },

--- a/test/DebuggerAgent.js
+++ b/test/DebuggerAgent.js
@@ -148,43 +148,43 @@ describe('DebuggerAgent', function() {
   describe('nodeVersionHasSetVariableValue', function() {
     it('returns false for v0.8.20', function(done) {
       expect(DebuggerAgent.nodeVersionHasSetVariableValue('v0.8.20'))
-        .to.be.false;
+        .to.equal(false);
       done();
     });
 
     it('returns false for v0.10.11', function(done) {
       expect(DebuggerAgent.nodeVersionHasSetVariableValue('v0.10.11'))
-        .to.be.false;
+        .to.equal(false);
       done();
     });
 
     it('returns true for v0.10.12', function(done) {
       expect(DebuggerAgent.nodeVersionHasSetVariableValue('v0.10.12'))
-        .to.be.true;
+        .to.equal(true);
       done();
     });
 
     it('returns false for v0.11.1', function(done) {
       expect(DebuggerAgent.nodeVersionHasSetVariableValue('v0.11.1'))
-        .to.be.false;
+        .to.equal(false);
       done();
     });
 
     it('returns true for v0.11.2', function(done) {
       expect(DebuggerAgent.nodeVersionHasSetVariableValue('v0.11.2'))
-        .to.be.true;
+        .to.equal(true);
       done();
     });
 
     it('returns true for v0.12.0', function(done) {
       expect(DebuggerAgent.nodeVersionHasSetVariableValue('v0.12.0'))
-        .to.be.true;
+        .to.equal(true);
       done();
     });
 
     it('returns true for v1.0.0', function(done) {
       expect(DebuggerAgent.nodeVersionHasSetVariableValue('v1.0.0'))
-        .to.be.true;
+        .to.equal(true);
       done();
     });
   });
@@ -193,8 +193,8 @@ describe('DebuggerAgent', function() {
     before(setupDebugScenario);
 
     it('truncates String values at 10,000 characters', function(done) {
-      var testExpression = "Array(10000).join('a');";
-      var expectedValue = Array(10000).join('a');
+      var testExpression = 'Array(10000).join("a");';
+      var expectedValue = new Array(10000).join('a');
 
       agent.evaluateOnCallFrame(
         {

--- a/test/DebuggerClient.js
+++ b/test/DebuggerClient.js
@@ -42,13 +42,13 @@ describe('DebuggerClient', function() {
     before(setupDebuggerClient);
 
     it('is updated on connect in --debug-brk mode', function(done) {
-      expect(debuggerClient.isRunning, 'isRunning').to.be.false;
+      expect(debuggerClient.isRunning, 'isRunning').to.equal(false);
       done();
     });
 
     it('is updated on break', function(done) {
       debuggerClient.on('break', function() {
-        expect(debuggerClient.isRunning, 'isRunning').to.be.false;
+        expect(debuggerClient.isRunning, 'isRunning').to.equal(false);
         done();
       });
 

--- a/test/RuntimeAgent.js
+++ b/test/RuntimeAgent.js
@@ -38,7 +38,7 @@ describe('RuntimeAgent', function() {
             var proto = result.result.filter(function(prop) {
               return prop.name == '__proto__';
             });
-            expect(proto.length == 0, 'proto in scope object is filtered').to.be.true;
+            expect(proto.length === 0, 'proto in scope object is filtered').to.equal(true);
             expect(result.result[0], 'local var 1').to.deep.equal({
               name: 'msg',
               writable: true,
@@ -89,7 +89,7 @@ describe('RuntimeAgent', function() {
             return prop.name == '__proto__';
           });
 
-          expect(proto.length == 0, 'null proto is filtered').to.be.true;
+          expect(proto.length === 0, 'null proto is filtered').to.equal(true);
 
           done();
         }
@@ -113,22 +113,22 @@ describe('RuntimeAgent', function() {
           var props = convertPropertyArrayToLookup(result.result);
 
           expect(props['writableProp'].configurable, 'writableProp.configurable')
-            .to.be.true;
+            .to.equal(true);
 
           expect(props['writableProp'].writable, 'writableProp.writable')
-            .to.be.true;
+            .to.equal(true);
 
           expect(props['writableProp'].enumerable, 'writableProp.enumerable')
-            .to.be.true;
+            .to.equal(true);
 
           expect(props['readonlyProp'].configurable, 'readonlyProp.configurable')
-            .to.be.false;
+            .to.equal(false);
 
           expect(props['readonlyProp'].writable, 'readonlyProp.writable')
-            .to.be.false;
+            .to.equal(false);
 
           expect(props['readonlyProp'].enumerable, 'readonlyProp.enumerable')
-            .to.be.false;
+            .to.equal(false);
 
           done();
         }
@@ -149,7 +149,7 @@ describe('RuntimeAgent', function() {
           if (error)
             return done(error);
 
-          expect(result.result).to.be.empty;
+          expect(result.result).to.have.length(0);
           done();
         });
     });
@@ -171,7 +171,7 @@ describe('RuntimeAgent', function() {
           var proto = result.result.filter(function(prop) {
             return prop.name == '__proto__';
           });
-          expect(proto.length == 1, 'proto exist and unique').to.be.true;
+          expect(proto.length == 1, 'proto exist and unique').to.equal(true);
           expect(proto[0], '__proto__ has valid structure').to.deep.equal({
               name: '__proto__',
               value: {
@@ -374,6 +374,7 @@ function verifyPropertyValue(runtimeAgent,
 
 // copied from front-end/RuntimeModel.js and replaced " with '
 function getCompletions(primitiveType) {
+  /*jshint -W053, proto:true */
   var object;
   if (primitiveType === 'string')
     object = new String('');

--- a/test/ScriptManager.js
+++ b/test/ScriptManager.js
@@ -9,7 +9,7 @@ describe('ScriptManager', function() {
     var frontendClientStub = {
       sendEvent: function() { }
     };
-    var debuggerClientStub = new EventEmitter;
+    var debuggerClientStub = new EventEmitter();
     manager = new ScriptManager([], frontendClientStub, debuggerClientStub);
   });
 
@@ -21,7 +21,7 @@ describe('ScriptManager', function() {
     });
 
     it('returns undefined for unknown id', function() {
-      expect(manager.findScriptByID('unknown-id')).to.be.undefined;
+      expect(manager.findScriptByID('unknown-id')).to.equal(undefined);
     });
   });
 
@@ -29,7 +29,7 @@ describe('ScriptManager', function() {
     it('removes all stored scripts', function() {
       manager._sources['id'] = 'a-source';
       manager.reset();
-      expect(manager.findScriptByID('id')).to.be.undefined;
+      expect(manager.findScriptByID('id')).to.equal(undefined);
     });
   });
 });

--- a/test/convert.js
+++ b/test/convert.js
@@ -176,19 +176,19 @@ describe('convert', function() {
   describe('v8ResultToInspectorResult', function() {
     it('convert regexp as object', function() {
       var v8Result = {
-            handle: 0,
-            className: 'RegExp',
-            type: 'regexp',
-            text: '/\/[^a]abc/'
-          },
-          ref = {
-            type: 'object',
-            subtype: 'regexp',
-            objectId: '0',
-            className: 'RegExp',
-            description: '/\/[^a]abc/'
-          },
-          converted = convert.v8ResultToInspectorResult(v8Result);
+          handle: 0,
+          className: 'RegExp',
+          type: 'regexp',
+          text: '/\/[^a]abc/'
+        },
+        ref = {
+          type: 'object',
+          subtype: 'regexp',
+          objectId: '0',
+          className: 'RegExp',
+          description: '/\/[^a]abc/'
+        },
+        converted = convert.v8ResultToInspectorResult(v8Result);
 
       expect(converted.type).to.equal(ref.type);
       expect(converted.objectId).to.equal(ref.objectId);
@@ -213,7 +213,7 @@ describe('convert', function() {
         'properties': [
           // stack, arguments, type, message
         ],
-        'text': "Error: ENOENT, open 'missing-file'"
+        'text': 'Error: ENOENT, open \'missing-file\''
       };
 
       var converted = convert.v8ResultToInspectorResult(v8Result);

--- a/test/fixtures/BreakInFunction.js
+++ b/test/fixtures/BreakInFunction.js
@@ -1,3 +1,4 @@
+/*jshint debug:true */
 function MyObj() {
 }
 

--- a/test/fixtures/InspectObject.js
+++ b/test/fixtures/InspectObject.js
@@ -1,3 +1,4 @@
+/*jshint debug:true */
 function InspectedClass() {
   this.writableProp = 'wr';
   Object.defineProperty(this, 'readonlyProp', { value: 'ro' });

--- a/test/fixtures/LiveEdit.js
+++ b/test/fixtures/LiveEdit.js
@@ -1,3 +1,4 @@
+/*jshint debug:true */
 process.stdin.once('data', function() {
   debugger;
 });

--- a/tools/generate-commands.js
+++ b/tools/generate-commands.js
@@ -1,3 +1,5 @@
+/* jshint evil:true */
+/* global InspectorBackendClass */
 var fs = require('fs'),
     protocol = require('./protocol.json');
 
@@ -6,9 +8,9 @@ eval(fs.readFileSync('./front-end/utilities.js', 'utf8'));
 eval(fs.readFileSync('./front-end/InspectorBackend.js', 'utf8'));
 
 var commands = InspectorBackendClass._generateCommands(protocol);
-var header = "// Auto-generated.\n" +
-             "// Run `node tools/generate-commands.js` to update.\n";
-             "\n";
+var header = '// Auto-generated.\n' +
+             '// Run `node tools/generate-commands.js` to update.\n' +
+             '\n';
 
 fs.writeFileSync('./front-end/InspectorBackendCommands.js', header + commands);
 

--- a/tools/gjslint.sh
+++ b/tools/gjslint.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-gjslint \
- --nojsdoc --max_line_length=105 \
- -r lib -r front-end/node -r test


### PR DESCRIPTION
Add jshint configuration, configure npm to run jshint in "pretest".

Fix existing issues to make jshint pass.

@3y3 please review

The most annoying change is replacing checks like `to.be.false` with `to.equal(false)`. Perhaps we could use [must](https://github.com/moll/js-must) instead of chai. Do you have any opinion on that?
