### PR TITLE
Fix for race condition in the debug server

### DIFF
--- a/front-end-node/Overrides.js
+++ b/front-end-node/Overrides.js
@@ -9,6 +9,7 @@ WebInspector.loaded = function() {
     var a = document.createElement('a');
     // browser will resolve this relative path to an absolute one
     a.href = 'ws';
+    a.search = window.location.search;
     a.protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
     return a.href;
   }();

--- a/lib/debug-server.js
+++ b/lib/debug-server.js
@@ -10,8 +10,6 @@ var http = require('http'),
     WEBROOT = path.join(__dirname, '../front-end');
 
 function debugAction(req, res) {
-  var config = this._config;
-  config.debugPort = getDebuggerPort(req.url, config.debugPort);
   res.sendfile(path.join(WEBROOT, 'inspector.html'));
 }
 
@@ -19,12 +17,9 @@ function overridesAction(req, res) {
   res.sendfile(path.join(__dirname, '../front-end-node/Overrides.js'));
 }
 
-function getDebuggerPort(url, defaultPort) {
-  return parseInt((/\?port=(\d+)/.exec(url) || [null, defaultPort])[1], 10);
-}
-
 function handleWebSocketConnection(socket) {
-  this._createSession().join(socket);
+  var debugPort = this._getDebuggerPort(socket.upgradeReq.url);
+  this._createSession(debugPort).join(socket);
 }
 
 function handleServerListening() {
@@ -63,8 +58,12 @@ DebugServer.prototype.start = function(options) {
   httpServer.listen(this._config.webPort, this._config.webHost);
 };
 
-DebugServer.prototype._createSession = function() {
-  return Session.create(this._config.debugPort, this._config);
+DebugServer.prototype._getDebuggerPort = function(url) {
+  return parseInt((/\?port=(\d+)/.exec(url) || [null, this._config.debugPort])[1], 10);
+};
+
+DebugServer.prototype._createSession = function(debugPort) {
+  return Session.create(debugPort, this._config);
 };
 
 DebugServer.prototype.close = function() {


### PR DESCRIPTION
Fixed a possible race condition by adding the port as a query parameter
for the websocket connection. If port number is not provided the
connection falls back to the last provided port number just as before 

closes #329
