### PR TITLE
Injector API

### DIFF
--- a/lib/BreakEventHandler.js
+++ b/lib/BreakEventHandler.js
@@ -6,12 +6,14 @@ var convert = require('./convert'),
  * @param {FrontendClient} frontendClient
  * @param {DebuggerClient} debuggerClient
  * @param {ScriptManager} scriptManager
+ * @param {InjectorClient} injectorClient
  * @constructor
  */
-function BreakEventHandler(config, frontendClient, debuggerClient, scriptManager) {
+function BreakEventHandler(config, frontendClient, debuggerClient, scriptManager, injectorClient) {
   this._config = config;
   this._frontendClient = frontendClient;
   this._debuggerClient = debuggerClient;
+  this._injectorClient = injectorClient;
   this._scriptManager = scriptManager;
   this._callFramesProvider = new CallFramesProvider(config, debuggerClient);
   this._registerDebuggerEventHandlers();
@@ -47,6 +49,9 @@ BreakEventHandler.prototype._onBreak = function(obj) {
     hitBreakpoints = obj.breakpoints,
     source = this._scriptManager.findScriptByID(scriptId);
 
+  if (this._injectorClient.tryHandleDebuggerBreak(obj.invocationText)) {
+    return;
+  }
   // Source is undefined when the breakpoint was in code eval()-ed via
   // console or eval()-ed internally by node inspector.
   // We could send backtrace in such case, but that isn't working well now.

--- a/lib/DebuggerAgent.js
+++ b/lib/DebuggerAgent.js
@@ -12,19 +12,22 @@ var convert = require('./convert.js'),
  * @param {DebuggerClient} debuggerClient
  * @param {BreakEventHandler} breakEventHandler
  * @param {ScriptManager} scriptManager
+ * @param {InjectorClient} injectorClient
  * @constructor
  */
 function DebuggerAgent(config,
                        frontendClient,
                        debuggerClient,
                        breakEventHandler,
-                       scriptManager) {
+                       scriptManager,
+                       injectorClient) {
   this._saveLiveEdit = config.saveLiveEdit;
   this._frontendClient = frontendClient;
   this._debuggerClient = debuggerClient;
   this._breakEventHandler = breakEventHandler;
   this._scriptManager = scriptManager;
-  this._scriptStorage = new ScriptFileStorage(config, scriptManager);
+  this._injectorClient = injectorClient;
+  this._scriptStorage = new ScriptFileStorage(config);
 }
 
 DebuggerAgent.prototype = {
@@ -54,7 +57,8 @@ DebuggerAgent.prototype = {
       //    disconnected from the debugged application
       this._removeAllBreakpoints.bind(this),
       this._reloadScripts.bind(this),
-      this._sendBacktraceIfPaused.bind(this)
+      this._sendBacktraceIfPaused.bind(this),
+      this._tryConnectInjector.bind(this)
     ]);
   },
 
@@ -111,6 +115,20 @@ DebuggerAgent.prototype = {
         done();
       }.bind(this)
     );
+  },
+
+  _tryConnectInjector: function(done) {
+    this._injectorClient.connect();
+    this._injectorClient.once('connect', function() { 
+      var cb = done;
+      done = function(){};
+      cb();
+    });
+    this._injectorClient.once('error', function(err) {
+      var cb = done;
+      done = function(){};
+      cb(err);
+    });
   },
 
   _sendBacktraceIfPaused: function(done) {

--- a/lib/FrontendCommandHandler.js
+++ b/lib/FrontendCommandHandler.js
@@ -11,12 +11,14 @@ var RuntimeAgent = require('./RuntimeAgent').RuntimeAgent,
  * @param {DebuggerClient} debuggerClient
  * @param {BreakEventHandler} breakEventHandler
  * @param {ScriptManager} scriptManager
+ * @param {InjectorClient} injectorClient
  */
 function FrontendCommandHandler(config,
                                 frontendClient,
                                 debuggerClient,
                                 breakEventHandler,
-                                scriptManager) {
+                                scriptManager,
+                                injectorClient) {
   this._config = config;
   this._agents = {};
   this._specialCommands = {};
@@ -24,6 +26,7 @@ function FrontendCommandHandler(config,
   this._debuggerClient = debuggerClient;
   this._breakEventHandler = breakEventHandler;
   this._scriptManager = scriptManager;
+  this._injectorClient = injectorClient;
   this._initializeRegistry();
   this._registerEventHandlers();
   this._pauseInitialEvents();
@@ -38,7 +41,8 @@ FrontendCommandHandler.prototype = {
         this._frontendClient,
         this._debuggerClient,
         this._breakEventHandler,
-        this._scriptManager)
+        this._scriptManager,
+        this._injectorClient)
     );
 
     this._registerAgent('Runtime', new RuntimeAgent(this._config, this._debuggerClient));

--- a/lib/InjectorClient.js
+++ b/lib/InjectorClient.js
@@ -1,0 +1,322 @@
+var EventEmitter = require('events').EventEmitter,
+    inherits = require('util').inherits,
+    injectorServer = require('./InjectorServer.js'),
+    DebugConnection = require('./debugger.js'),
+    debug = require('debug')('node-inspector:injector');
+
+var PAUSE_MARK = '__injector_break__',
+    PAUSE_STRING = 'process.once("' + PAUSE_MARK + '", function ' + PAUSE_MARK + '(){debugger;});' +
+                   'process.emit("' + PAUSE_MARK + '")',
+    PAUSE_CHECK = '#<process>.' + PAUSE_MARK + '()',
+    PARENT_CALL_FRAME = 1,
+    CURRENT_CALL_FRAME = 0,
+    NOOP = function() {};
+
+/**
+ * @param {Array} messagesCache
+ * @type {Object}
+ */
+function createFailingConnection() {
+  return {
+    isRunning: false,
+    connected: false,
+    send: NOOP,
+    close: NOOP
+  };
+}
+
+/**
+ * @param {{inject}} config
+ * @param {DebuggerClient} debuggerClient
+ * @constructor
+ */
+function InjectorClient(config, debuggerClient) {
+  this._noInject = config.inject === false;
+  this._appPausedByInjector = false;
+  this._needsToInject = [];
+  this._needsToInjectOptions = [];
+  this._eventNames = [];
+  this._messagesCache = [];
+  this._conn = createFailingConnection();
+  this.on('error', function(error){
+    debug('injector: ' + error.message);
+  });
+
+  this._debuggerClient = debuggerClient;
+  this._debuggerClient.on('close', this.close.bind(this));
+}
+
+inherits(InjectorClient, EventEmitter);
+
+Object.defineProperties(InjectorClient.prototype, {
+  /** @type {boolean} */
+  needsConnect: {
+    get: function() {
+      return !this._noInject && !this._conn.connected;
+    }
+  },
+  /** @type {boolean} */
+  isConnected: {
+    get: function() {
+      return this._conn.connected;
+    }
+  }
+});
+
+/**
+ * @param {string} sourceLine
+ * @type {boolean}
+ */
+InjectorClient.prototype.tryHandleDebuggerBreak = function(sourceLine) {
+  var pausedByInjector = this.containsInjectorMark(sourceLine);
+  var handledByInjector = this.needsConnect && pausedByInjector;
+  if (handledByInjector) {
+    this._appPausedByInjector = true;
+    this.connect();
+  } else if (pausedByInjector) {
+    this._debuggerClient.request('continue');
+  }
+  return handledByInjector;
+};
+
+/**
+ * @param {string} sourceLine
+ * @type {boolean}
+ */
+InjectorClient.prototype.containsInjectorMark = function(sourceLine) {
+  return sourceLine === PAUSE_CHECK;
+};
+
+/**
+ */
+InjectorClient.prototype.connect = function() {
+  if (!this.needsConnect) {
+    this.emit('connect', false);
+    return;
+  }
+
+  if (!this._debuggerClient.isRunning) {
+    if (this._appPausedByInjector) {
+      this._injectServer(this._connect.bind(this), PARENT_CALL_FRAME);
+    } else {
+      this._ifRequireInFrame(
+        this._injectServer.bind(this,
+          this._connect.bind(this), CURRENT_CALL_FRAME));
+    }
+  } else {
+    this._pause();
+  }
+};
+
+/**
+* @param {function(error, result)} done
+*/
+InjectorClient.prototype._ifRequireInFrame = function(done) {
+  this._debuggerClient.request(
+    'evaluate',
+    {
+      expression: 'require',
+      frame: CURRENT_CALL_FRAME
+    },
+    done
+  );
+};
+
+/**
+ */
+InjectorClient.prototype._pause = function() {
+  this._debuggerClient.request(
+    'evaluate',
+    {
+      global: true,
+      expression: PAUSE_STRING
+    }
+  );
+};
+
+/**
+ * @param {Object} error
+ * @param {{value}} result
+ */
+InjectorClient.prototype._connect = function(error, result) {
+  if (error) {
+    /**
+     * @event InjectorClient#error
+     * @type {boolean}
+     */
+    this.emit('error', error);
+  } else {
+    var serverPort = result.value;
+    this._conn = DebugConnection.attachDebugger(serverPort);
+    this._conn
+      .on('connect', this._onConnectionOpen.bind(this))
+      .on('error', this._onConnectionError.bind(this))
+      .on('close', this._onConnectionClose.bind(this));
+    this._registerInjectorEventHandlers();
+  }
+
+  if (this._appPausedByInjector) {
+    this._debuggerClient.request('continue');
+    this._appPausedByInjector = false;
+  }
+};
+
+InjectorClient.prototype._registerInjectorEventHandlers = function() {
+  this._eventNames.forEach(function(name) {
+    this._conn.on(name, this._emitInjectorEvent.bind(this, name));
+  }, this);
+  this._eventNames.length = 0;
+};
+
+/**
+ * @param {...string} eventNames
+ */
+InjectorClient.prototype.registerInjectorEvents = function(eventNames) {
+  for (var i in arguments) {
+    var name = arguments[i];
+    this._eventNames.push(name);
+  }
+};
+
+InjectorClient.prototype._onConnectionOpen = function() {
+  if (this._messagesCache.length) {
+    this._messagesCache.forEach(function(message) {
+      if (message.type === 'event') {
+        this.sendEvent.apply(this, message.args);
+      } else if (message.type === 'request') {
+        this.request.apply(this, message.args);
+      }
+    }, this);
+    this._messagesCache.length = 0;
+  }
+  /**
+   * @event InjectorClient#connect
+   * @type {boolean}
+   * Emit true when connection opened.
+   */
+  this.emit('connect', true);
+};
+
+/**
+ * @param {string} reason
+ */
+InjectorClient.prototype._onConnectionError = function(error) {
+  /**
+   * @event InjectorClient#error
+   * @type {boolean}
+   * Emit Error on connection error.
+   */
+  this.emit('error', error);
+};
+
+/**
+ * @param {boolean} withErrors
+ */
+InjectorClient.prototype._onConnectionClose = function(withErrors) {
+  this._conn = createFailingConnection();
+  /**
+   * @event InjectorClient#close
+   * @type {boolean}
+   * Emit withErrors=true if closed with errors.
+   */
+  this.emit('close', withErrors);
+};
+
+/**
+ * @param {string} name
+ * @param {{body}} message
+ */
+InjectorClient.prototype._emitInjectorEvent = function(name, message) {
+  this.emit(name, message.body);
+};
+
+/**
+ */
+InjectorClient.prototype.close = function() {
+  this._conn.close();
+};
+
+/**
+ * @param {function(require, injector, options)} injection
+ * @param {Object} options
+ */
+InjectorClient.prototype.inject = function(injection, options) {
+  options = options || {};
+
+  this._needsToInject.push(injection.toString());
+  this._needsToInjectOptions.push(JSON.stringify(options));
+};
+
+/**
+ * @param {function(error, result)} done
+ * @param {Number} frameIndex
+ * @param {Error} error
+ */
+InjectorClient.prototype._injectServer = function(done, frameIndex, error) {
+  if (error) {
+    done(error);
+    return;
+  }
+
+  var injectorServerPath = JSON.stringify(require.resolve('./InjectorServer'));
+  var injection = 'require(\'module\')._load(' + injectorServerPath + ')' +
+                  '([' + this._needsToInject.join(',') + ']'+
+                  ',[' + this._needsToInjectOptions.join(',') + '])';
+
+  this._needsToInject = null;
+  this._needsToInjectOptions = null;
+
+  this._debuggerClient.request(
+    'evaluate',
+    {
+      expression: injection,
+      frame: frameIndex || CURRENT_CALL_FRAME
+    },
+    done
+  );
+};
+
+/**
+ * @param {string} eventName
+ * @param {Object} messageBody
+ */
+InjectorClient.prototype.sendEvent = function(eventName, messageBody) {
+  var message = {
+    seq: 0,
+    type: 'event',
+    event: eventName,
+    body: messageBody
+  };
+  if (this.isConnected) {
+    this._conn.send(JSON.stringify(message));
+  } else {
+    this._messagesCache.push({type: 'event', args: [eventName, messageBody]});
+  }
+};
+
+/**
+ * @param {string} command
+ * @param {!Object} args
+ * @param {function(error, response, refs)} callback
+ */
+InjectorClient.prototype.request = function(command, args, callback) {
+  if (typeof callback !== 'function') {
+    callback = function(error) {
+      if (!error) return;
+      console.log('Warning: ignored Injector error. %s', error);
+    };
+  }
+  if (this.isConnected) {
+    this._conn.request(command, { arguments: args }, function(response) {
+      if (!response.success)
+        callback(response.message);
+      else {
+        callback(null, response.body);
+      }
+    });
+  } else {
+    this._messagesCache.push({type: 'request', args: [command, args, callback]});
+  }
+};
+
+module.exports.InjectorClient = InjectorClient;

--- a/lib/InjectorServer.js
+++ b/lib/InjectorServer.js
@@ -1,0 +1,154 @@
+/**
+* @param {Array} injections
+*/
+function injectorServer(injections, options) {
+  var injector,
+      connection,
+      server = require('net').createServer(),
+      Protocol = require('_debugger').Protocol,
+      inherits = require('util').inherits,
+      EventEmitter = require('events').EventEmitter,
+      connected = false,
+      next_response_seq = 0;
+  
+  /**
+  * @param {Object?} request
+  */
+  function ProtocolMessage(request) {
+    this.seq = next_response_seq++;
+
+    if (request) {
+      this.type = 'response';
+      this.request_seq = request.seq;
+      this.command = request.command;
+      this.running = true;
+    } else {
+      this.type = 'event';
+    }
+    this.success = true;
+  }
+  
+  /**
+  */
+  function Injector() {
+    this._connection = null;
+    this._messagesCache = [];
+    this.commands = {};
+  }
+
+  inherits(Injector, EventEmitter);
+
+  Object.defineProperties(Injector.prototype, {
+  /** @type {boolean} */
+    connected: {
+      get: function() {
+        return connected;
+      }
+    }
+  });
+
+  /**
+  * @param {string} message
+  */
+  Injector.prototype.send = function(message) {
+    if (this.connected) {
+      var data = 'Content-Length: ' + Buffer.byteLength(message, 'utf8') + '\r\n\r\n' + message;
+      this._connection.write(data);
+    }
+    else {
+      this._messagesCache.push(message);
+    }
+  };
+
+  /**
+  * @param {string} eventName
+  * @param {Object} messageBody
+  */
+  Injector.prototype.sendEvent = function(eventName, messageBody) {
+    var message = new ProtocolMessage();
+    message.event = eventName;
+    message.body = messageBody;
+    this.send(JSON.stringify(message));
+  };
+  
+  /**
+  */
+  Injector.prototype.close = function() {
+    this.emit('close');
+    this.removeAllListeners();
+    this._connection.close();
+    this._connection = null;
+    this._messageCache = null;
+    this.commands = null;
+  };
+
+  /**
+  * @param {Socket} connection
+  */
+  function attachInjector(connection) {
+    var protocol = new Protocol();
+    protocol.onResponse = processResponse.bind(injector);
+    
+    connection
+      .on('data', protocol.execute.bind(protocol))
+      .on('error', console.error.bind(console))
+      .on('close', detachInjector);
+
+    connected = true;
+
+    injector._connection = connection;
+    injector._messagesCache.forEach(injector.send, injector);
+    injector._messagesCache.length = 0;
+    injector.emit('connect');
+  }
+
+  /**
+  * @param {boolean} error
+  */
+  function detachInjector(error) {
+    injector.close();
+    connected = false;
+    server
+      .removeAllListeners()
+      .close();
+
+    server = null;
+  }
+
+  function processResponse(message){
+    message = message.body;
+    switch (message.type) {
+      case 'event':
+        injector.emit(message.event, message);
+        break;
+      case 'request':
+        var response = new ProtocolMessage(message);
+        try {
+          injector.commands[message.command](message, response);
+        } catch (e) {
+          response.success = false;
+          response.message = e.message;
+        }
+        this.send(JSON.stringify(response));
+        break;
+      default:
+        console.log('Unknown message type: ' + message.type);
+        break;
+    }
+  }
+  
+  server
+    .on('connection', attachInjector)
+    .on('error', console.error.bind(console))
+    .listen()
+    .unref();
+
+  injector = new Injector();
+  injections.forEach(function(injection, i) {
+    injection(require, injector, options[i]);
+  });
+  
+  return server.address().port;
+}
+
+module.exports = injectorServer;

--- a/lib/config.js
+++ b/lib/config.js
@@ -92,6 +92,11 @@ var definitions = {
     convert: conversions.stringToBoolean,
     defaultValue: true
   },
+  'inject': {
+    desc: 'Enables injection of debugger extensions in app',
+    convert: conversions.stringToBoolean,
+    defaultValue: true
+  },
   'hidden': {
     desc: 'Array of files to hide from the UI (breakpoints in these files' +
           ' will be ignored)',

--- a/lib/session.js
+++ b/lib/session.js
@@ -4,7 +4,8 @@ var events = require('events'),
     ScriptManager = require('./ScriptManager').ScriptManager,
     FrontendClient = require('./FrontendClient').FrontendClient,
     FrontendCommandHandler = require('./FrontendCommandHandler').FrontendCommandHandler,
-    BreakEventHandler = require('./BreakEventHandler').BreakEventHandler;
+    BreakEventHandler = require('./BreakEventHandler').BreakEventHandler,
+    InjectorClient = require('./InjectorClient').InjectorClient;
 
 
 ///////////////////////////////////////////////////////////
@@ -16,6 +17,7 @@ exports.create = function(debuggerPort, config) {
       frontendCommandHandler,
       frontendClient,
       debuggerClient,
+      injectorClient,
       breakEventHandler;
 
   function onDebuggerClientClose(reason) {
@@ -29,6 +31,11 @@ exports.create = function(debuggerPort, config) {
     if (e.helpString) {
       err += '\n' + e.helpString;
     }
+    frontendClient.sendLogToConsole('error', err);
+  }
+  
+  function onInjectorClientError(e) {
+    var err = e.toString();
     frontendClient.sendLogToConsole('error', err);
   }
 
@@ -46,6 +53,11 @@ exports.create = function(debuggerPort, config) {
         frontendClient = new FrontendClient(wsConnection);
         debuggerClient = new DebuggerClient(debuggerPort);
 
+        injectorClient = new InjectorClient(
+          config,
+          debuggerClient
+        );
+
         scriptManager = new ScriptManager(
           config.isScriptHidden,
           frontendClient,
@@ -56,7 +68,8 @@ exports.create = function(debuggerPort, config) {
           config,
           frontendClient,
           debuggerClient,
-          scriptManager
+          scriptManager,
+          injectorClient
         );
 
         frontendCommandHandler = new FrontendCommandHandler(
@@ -64,12 +77,15 @@ exports.create = function(debuggerPort, config) {
           frontendClient,
           debuggerClient,
           breakEventHandler,
-          scriptManager);
+          scriptManager,
+          injectorClient
+        );
 
         frontendClient.on('close', this.close.bind(this));
 
         debuggerClient.on('close', onDebuggerClientClose);
         debuggerClient.on('error', onDebuggerClientError);
+        injectorClient.on('error', onInjectorClientError);
       }
     }
   });

--- a/test/FrontendCommandHandler.test.js
+++ b/test/FrontendCommandHandler.test.js
@@ -5,6 +5,7 @@ var FrontendCommandHandler = require('../lib/FrontendCommandHandler.js').Fronten
 var FrontendClient = require('../lib/FrontendClient.js').FrontendClient;
 var ScriptFileStorage = require('../lib/ScriptFileStorage.js').ScriptFileStorage;
 var ScriptManager = require('../lib/ScriptManager.js').ScriptManager;
+var InjectorClient = require('../lib/InjectorClient.js').InjectorClient;
 var WebSocketMock = require('./helpers/wsmock');
 
 describe('FrontendCommandHandler', function() {
@@ -71,6 +72,7 @@ describe('FrontendCommandHandler', function() {
       isHidden: function() { return false; }
     };
 
+    var injectorClient = new InjectorClient({inject: false}, debuggerClient);
     var frontendClient = new FrontendClient(wsclient);
 
     var scriptManager = new ScriptManager(
@@ -85,6 +87,7 @@ describe('FrontendCommandHandler', function() {
       frontendClient,
       debuggerClient,
       breakEventHandlerMock,
-      scriptManager);
+      scriptManager,
+      injectorClient);
   }
 });

--- a/test/InjectorClient.js
+++ b/test/InjectorClient.js
@@ -1,0 +1,260 @@
+var expect = require('chai').expect,
+    InjectorClient = require('../lib/InjectorClient').InjectorClient,
+    launcher = require('./helpers/launcher.js');
+
+describe('InjectorClient', function() {
+  describe('with inject=false', function() {
+    var injectorClient, debuggerClient, breakedObject;
+
+    function setupInjector(done) {
+      launcher.runPeriodicConsoleLog(false, function(childProcess, client) {
+        debuggerClient = client;
+        injectorClient = new InjectorClient({inject: false}, debuggerClient);
+        debuggerClient.once('break', function(obj) {
+          breakedObject = obj;
+          done();
+        });
+        injectorClient._pause();
+      });
+    }
+
+    before(setupInjector);
+
+    it('ignores break events not created by the injector', function() {
+      var pausedByInjector = injectorClient.containsInjectorMark('wrongInvocationText');
+      expect(pausedByInjector, 'invocation text not equal to PAUSE_CHECK').to.equal(false);
+    });
+
+    it('checks that application paused by injector', function() {
+      var pausedByInjector = injectorClient.containsInjectorMark(breakedObject.invocationText);
+      expect(pausedByInjector, 'invocation text equal to PAUSE_CHECK').to.equal(true);
+    });
+
+    it('breaks the connection flow with connected=false', function(done) {
+      injectorClient.once('connect', function(connected) {
+        expect(connected, 'connection command discarded').to.equal(false);
+        done();
+      });
+      injectorClient.connect();
+    });
+
+    it('caches injections as stringified functions', function() {
+      var injection = function(require, injector) {},
+          injToString = injection.toString();
+      injectorClient.inject(injection);
+
+      var cached = injectorClient._needsToInject;
+
+      expect(cached, 'injections cache length').to.have.length(1);
+      expect(cached, 'injection in cache').to.include(injToString);
+    });
+  });
+
+  describe('with inject=true', function() {
+    before(setupInjector);
+    var injectorClient, debuggerClient, serverPort;
+
+    function setupInjector(done) {
+      launcher.runPeriodicConsoleLog(false, function(childProcess, client) {
+        debuggerClient = client;
+        injectorClient = new InjectorClient({}, debuggerClient);
+        injectorClient._pause();
+        debuggerClient.once('break', function(obj) {
+          injectorClient._appPausedByInjector = injectorClient.containsInjectorMark(obj.invocationText);
+          done();
+        });
+      });
+    }
+
+    it('is ready to inject', function() {
+      expect(injectorClient.needsConnect, 'connection allowed').to.equal(true);
+    });
+    
+    it('inject server', function(done) {
+      injectorClient._injectServer(function(error, result) {
+        expect(error, 'injectet without errors').to.equal(null);
+        expect(result.value, 'port is a valid number').to.be.within(0, 65535);
+        serverPort = result.value;
+        done();
+      }, 1);
+    });
+
+    it('connects to server', function(done) {
+      injectorClient._connect(null, {value: serverPort});
+      injectorClient.once('connect', function(connected) {
+        expect(connected, 'is connected').to.equal(true);
+        done();
+      });
+    });
+    
+    it('does not need to connect if connected', function() {
+      expect(injectorClient.needsConnect, 'connection not allowed').to.equal(false);
+    });
+    
+    it('discards connection command if connected', function(done) {
+      injectorClient.once('connect', function(connected) {
+        expect(connected, 'connection command discarded').to.equal(false);
+        done();
+      });
+      injectorClient.connect();
+    });
+
+    it('would close on "close" debuggerClient', function(done) {
+      injectorClient.on('close', done.bind(undefined, null));
+      debuggerClient.close();
+    });
+    
+    it('is ready to inject after close', function() {
+      expect(injectorClient.needsConnect, 'connection allowed').to.equal(true);
+    });
+  });
+
+  describe('works with events.', function() {
+    before(setupInjector);
+    var injectorClient, debuggerClient;
+
+    function setupInjector(done) {
+      launcher.runPeriodicConsoleLog(false, function(childProcess, client) {
+        debuggerClient = client;
+        injectorClient = new InjectorClient({}, debuggerClient);
+        injectorClient.inject(function(require, injector) {
+          injector.on(
+            'Agent.clientEvent',
+            function(message) {
+              injector.sendEvent('Agent.serverEvent', message.body);
+            }
+          );
+        });
+        injectorClient._pause();
+        debuggerClient.once('break', function(obj) {
+          injectorClient._appPausedByInjector = injectorClient.containsInjectorMark(obj.invocationText);
+          done();
+        });
+      });
+    }
+
+    it('Register events', function() {
+      var events = ['Agent.serverEvent', 'Agent.serverEventOther'];
+      injectorClient.registerInjectorEvents.apply(injectorClient, events);
+
+      var cached = injectorClient._eventNames;
+
+      expect(cached, 'events cache length').to.have.length(2);
+      expect(cached, 'cache contains event').to.have.members(events);
+    });
+
+    it('Cache messages if not connected', function() {
+      injectorClient.sendEvent('Agent.clientEvent', 'test1');
+      injectorClient.sendEvent('Agent.clientEvent', 'test2');
+
+      var cached = injectorClient._messagesCache;
+
+      expect(cached, 'messages cache length').to.have.length(2);
+    });
+
+    it('Receive events', function(done) {
+      var result = [];
+      injectorClient.on('Agent.serverEvent', function(message) {
+        result.push(message);
+        if (result.length == 2) {
+          expect(result, 'events has true ordered').to.deep.equal(['test1', 'test2']);
+          done();
+        }
+      });
+      injectorClient.connect();
+    });
+
+    it('Clear messages cache after connection', function() {
+      expect(injectorClient._messagesCache).to.have.length(0);
+    });
+  });
+  
+  describe('works with requests.', function() {
+    before(setupInjector);
+    var injectorClient, debuggerClient;
+
+    function setupInjector(done) {
+      launcher.runPeriodicConsoleLog(false, function(childProcess, client) {
+        debuggerClient = client;
+        injectorClient = new InjectorClient({}, debuggerClient);
+        injectorClient.inject(function(require, injector) {
+          injector.commands['Agent.clientRequest'] = function(request, response) {
+            response.body = request.arguments;
+          };
+          injector.commands['Agent.clientBadRequest'] = function(request, response) {
+            response.body = {result: true};
+            throw new Error('Bad request was thrown');
+          };
+        });
+        injectorClient._pause();
+        debuggerClient.once('break', function(obj) {
+          injectorClient._appPausedByInjector = injectorClient.containsInjectorMark(obj.invocationText);
+          done();
+        });
+      });
+    }
+    
+    it('Cache messages when not connected', function() {
+      injectorClient.request('Agent.clientRequest');
+      injectorClient.sendEvent('Agent.clientBadRequest');
+
+      var cached = injectorClient._messagesCache;
+
+      expect(cached, 'messages cache length').to.have.length(2);
+    });
+    
+    it('Receive responces when connected', function(done) {
+      var doneCounter = 0;
+      injectorClient.connect();
+      
+      injectorClient.request('Agent.clientRequest', {param: 1}, function(error, response){
+        expect(error, 'no errors').to.equal(null);
+        expect(response.param, 'param was passed').to.equal(1);
+        if (++doneCounter == 2) done();
+      });
+      injectorClient.request('Agent.clientBadRequest', {}, function(error, response) {
+        expect(error, 'error was thrown').to.equal('Bad request was thrown');
+        expect(response, 'response is empty').to.equal(undefined);
+        if (++doneCounter == 2) done();
+      });
+    });
+  });
+
+  describe('with inject=true and debug-brk flag', function() {
+    before(setupInjector);
+    var injectorClient, debuggerClient;
+
+    function setupInjector(done) {
+      launcher.runPeriodicConsoleLog(true, function(childProcess, client) {
+        debuggerClient = client;
+        injectorClient = new InjectorClient({}, debuggerClient);
+        injectorClient.inject(function(require, injector) {
+          console.log = (function(fn) {
+            return function() {
+              injector.sendEvent('Console.messageAdded', arguments[0]);
+              fn.apply(console, arguments);
+            };
+          }(console.log));
+        });
+        injectorClient.registerInjectorEvents('Console.messageAdded');
+        done();
+      });
+    }
+
+    it('connects to server', function(done) {
+      injectorClient.once('connect', function(connected) {
+        expect(connected, 'is connected').to.equal(true);
+        done();
+      });
+      injectorClient.connect();
+    });
+
+    it('does not lose the data', function(done) {
+      debuggerClient.request('continue');
+      injectorClient.once('Console.messageAdded', function(message) {
+        expect(message).to.equal(0);
+        done();
+      });
+    });
+  });
+});

--- a/test/fixtures/PeriodicConsoleLog.js
+++ b/test/fixtures/PeriodicConsoleLog.js
@@ -1,0 +1,5 @@
+var a = 0;
+console.log(a);
+setInterval(function(){
+  console.log(++a);
+}, 1000);

--- a/test/helpers/launcher.js
+++ b/test/helpers/launcher.js
@@ -76,6 +76,17 @@ function runInspectObject(test) {
   });
 }
 
+function runPeriodicConsoleLog(breakOnStart, test) {
+  stopAllDebuggers();
+  startDebugger(
+    'PeriodicConsoleLog.js',
+    breakOnStart,
+    function(childProcess, debuggerClient) {
+      test(childProcess, debuggerClient);
+    }
+  );
+}
+
 function stopAllDebuggers() {
   while (stopDebuggerCallbacks.length > 0)
     stopDebuggerCallbacks.shift()();
@@ -107,6 +118,7 @@ function injectTestHelpers(debuggerClient) {
 
 exports.startDebugger = startDebugger;
 exports.runOnBreakInFunction = runOnBreakInFunction;
+exports.runPeriodicConsoleLog = runPeriodicConsoleLog;
 exports.stopAllDebuggers = stopAllDebuggers;
 exports.stopAllDebuggersAfterEachTest = stopAllDebugersAfterEachTest;
 exports.runInspectObject = runInspectObject;


### PR DESCRIPTION
Injector presents a communication bridge between app and debugger.
It provide the access to:
1. 'require' function (that isn't global and rarely scoped)
2. socket connection (that used V8 debugger protocol in messages)
   as main communication channel between app and debugger.
   It will be useful for injection of plugins and extentions.
   It is first part of 'Console API', 'Profiler API', 'HeapProfiler API' extensions.
