### PR TITLE
ScriptFileStorage: fix fs.readFile usage on v0.8

### DIFF
--- a/lib/ScriptFileStorage.js
+++ b/lib/ScriptFileStorage.js
@@ -58,7 +58,7 @@ $class.save = function(path, content, callback) {
 $class.load = function(path, callback) {
   fs.readFile(
     path,
-    { encoding: 'utf-8' },
+    'utf-8',
     function(err, content) {
       if (err) return callback(err);
 


### PR DESCRIPTION
Pass the fs.readFile encoding as a string instead in an options object.

The options object was introduced by Node v0.10 and is not available in
Node v0.8. When called with the options object, Node v0.8 calls the
callback with a Buffer instead of a string, which causes type error
`content has no method 'replace'`.

/to @3y3 please review

Close #335.
