### PR TITLE
Fix tests for NodeJS v0.11.13. Close #369

### DIFF
--- a/test/CallFramesProvider.js
+++ b/test/CallFramesProvider.js
@@ -16,7 +16,7 @@ describe('CallFramesProvider', function() {
         }
 
         // The order of script loading has changed in v0.11
-        var scriptId = /^v0\.10\./.test(process.version) ? '28' : '32';
+        var scriptId = /^v0\.10\./.test(process.version) ? '28' : '36';
 
         expect(callFrames).to.have.length.least(2);
 


### PR DESCRIPTION
From v0.11.13 order of script loading was changed again.
Missed test's compatibility for v0.11.(< 13)

Close #369
