### PR TITLE
test: increase test timeout in InjectorClient

### DIFF
--- a/test/InjectorClient.js
+++ b/test/InjectorClient.js
@@ -107,6 +107,9 @@ describe('InjectorClient', function() {
     var injectorClient, debuggerClient;
 
     function setupInjector(done) {
+      // increase the timeout for Travis CI
+      this.timeout(5000);
+
       launcher.runPeriodicConsoleLog(true, function(childProcess, client) {
         debuggerClient = client;
         injectorClient = new InjectorClient({}, debuggerClient);
@@ -128,6 +131,9 @@ describe('InjectorClient', function() {
     var injectorClient, debuggerClient;
 
     function setupInjector(done) {
+      // increase the timeout for Travis CI
+      this.timeout(5000);
+
       launcher.runPeriodicConsoleLog(true, function(childProcess, client) {
         debuggerClient = client;
         injectorClient = new InjectorClient({}, debuggerClient);
@@ -185,6 +191,9 @@ describe('InjectorClient', function() {
     var injectorClient, debuggerClient;
 
     function setupInjector(done) {
+      // increase the timeout for Travis CI
+      this.timeout(5000);
+
       launcher.runPeriodicConsoleLog(true, function(childProcess, client) {
         debuggerClient = client;
         injectorClient = new InjectorClient({}, debuggerClient);


### PR DESCRIPTION
The test setup takes more than 2 seconds in Travis CI, which caused the
build to fail. The timeout is 5 seconds now, which seems to be enough.

See also #428

/cc @3y3 this patch is IMHO not worth reviewing
