### PR TITLE
Overrides: fix `WebInspector.UIString`

### DIFF
--- a/front-end-node/Overrides.js
+++ b/front-end-node/Overrides.js
@@ -206,8 +206,9 @@ var stringOverrides = {
   '(no domain)': '(core modules)'
 };
 WebInspector.UIString = function(string, vararg) {
-  string = stringOverrides[string] || string;
-  return oldUIString(string, Array.prototype.slice.call(arguments, 1));
+  var args = Array.prototype.slice.call(arguments);
+  args[0] = stringOverrides[string] || string;
+  return oldUIString.apply(this, args);
 };
 
 // Hide chrome-specific elements


### PR DESCRIPTION
Fix `WebInspector.UIString` to correctly pass all arguments to the original method.

Before this patch, `WebInspector.UIString('%.1f', 0.11)` incorrectly called `UIString('%.1f', [0.11])`.

@3y3 please review
