### PR TITLE
Updated Readme: debugging Gulp tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,16 +178,17 @@ $ node-debug _mocha
 
 #### How do I debug Gulp tasks?
 
-If you are running on a Unix system you can simply run.  The `$(which ..)` statement gets replaced with the full path to the gulp-cli.
+If you are running on a Unix system you can simply run the following command. 
+The `$(which ..)` statement gets replaced with the full path to the gulp-cli.
 
 ```sh
-node-debug $(which gulp) task
+$ node-debug $(which gulp) task
 ```
 
 If you are running on Windows, you have to get the full path of `gulp.js` to make an equivalent command:
 
 ```sh
-node-debug "C:\Users\user\AppData\Roaming\npm\node_modules\gulp\bin\gulp.js" task
+> node-debug "C:\Users\user\AppData\Roaming\npm\node_modules\gulp\bin\gulp.js" task
 ```
 *You can omit the `task` part to run the `default` task.*
 


### PR DESCRIPTION
Adds documentation on how to debug Gulp tasks.

Solves #447 and #348.

**Unix:**

``` sh
node-debug $(which gulp) task
```

**Window:**

``` sh
node-debug "C:\Users\user\AppData\Roaming\npm\node_modules\gulp\bin\gulp.js" task
```
