### PR TITLE
Check Windows case insensitive app name

### DIFF
--- a/lib/DebuggerAgent.js
+++ b/lib/DebuggerAgent.js
@@ -331,9 +331,12 @@ DebuggerAgent.prototype = {
       return;
     }
 
+    var target = convert.inspectorUrlToV8Name(params.url,
+      this._scriptManager.normalizeV8Name.bind(this._scriptManager));
+
     var requestParams = {
       type: 'script',
-      target: convert.inspectorUrlToV8Name(params.url),
+      target: target,
       line: params.lineNumber,
       column: params.columnNumber,
       condition: params.condition

--- a/lib/PageAgent.js
+++ b/lib/PageAgent.js
@@ -76,7 +76,6 @@ extend(PageAgent.prototype, {
 
   _resolveMainAppScript: function(startDirectory, mainAppScript, done) {
     this._scriptManager.mainAppScript = mainAppScript;
-
     if (mainAppScript == null) {
       // mainScriptFile is null when running in the REPL mode
       return done(null, startDirectory, mainAppScript);
@@ -86,8 +85,26 @@ extend(PageAgent.prototype, {
       if (err && !/\.js$/.test(mainAppScript)) {
         mainAppScript += '.js';
       }
-      return done(null, startDirectory, mainAppScript);
-    });
+
+      if (process.platform !== 'win32') {
+        this._scriptManager.realMainAppScript = mainAppScript;
+        return done(null, startDirectory, mainAppScript);
+      }
+      
+      var dirname = path.dirname(mainAppScript);
+      var basename = path.basename(mainAppScript);
+
+      fs.readdir(dirname, function(err, files) {
+        var realBaseName = files.filter(function(filename) {
+          return filename.toLowerCase() == basename.toLowerCase();
+        })[0];
+
+        mainAppScript = path.join(dirname, realBaseName);
+        this._scriptManager.realMainAppScript = mainAppScript;
+
+        return done(null, startDirectory, mainAppScript);
+      }.bind(this));
+    }.bind(this));
   },
 
   _getResourceTreeForAppScript: function(startDirectory, mainAppScript, done) {
@@ -135,7 +152,8 @@ extend(PageAgent.prototype, {
   },
 
   getResourceContent: function(params, done) {
-    var scriptName = convert.inspectorUrlToV8Name(params.url);
+    var scriptName = convert.inspectorUrlToV8Name(params.url,
+      this._scriptManager.normalizeV8Name.bind(this._scriptManager));
 
     if (scriptName === '') {
       // When running REPL, main application file is null

--- a/lib/ScriptManager.js
+++ b/lib/ScriptManager.js
@@ -27,6 +27,8 @@ function ScriptManager(config, frontendClient, debuggerClient) {
 ScriptManager.prototype = Object.create(events.EventEmitter.prototype, {
   mainAppScript: { value: null, writable: true },
 
+  realMainAppScript: { value: null, writable: true },
+
   _registerDebuggerEventHandlers: {
     value: function() {
       this._debuggerClient.on(
@@ -79,7 +81,7 @@ ScriptManager.prototype = Object.create(events.EventEmitter.prototype, {
       });
     }
   },
-  
+
   findScriptByID: {
     /**
      * @param {string} id script id.
@@ -93,6 +95,10 @@ ScriptManager.prototype = Object.create(events.EventEmitter.prototype, {
   addScript: {
     value: function(v8data) {
       var localPath = v8data.name;
+      if (this._isMainAppScript(localPath)) {
+        v8data.name = localPath = this.realMainAppScript;
+      }
+
       var hidden = this.isScriptHidden(localPath) && localPath != this.mainAppScript;
 
       var inspectorScriptData = this._doAddScript(v8data, hidden);
@@ -130,6 +136,26 @@ ScriptManager.prototype = Object.create(events.EventEmitter.prototype, {
           inspectorScriptData
         );
       }
+    }
+  },
+
+  _isMainAppScript: {
+    value: function(path) {
+      if (!path || !this.mainAppScript) return false;
+      if (process.platform == 'win32')
+        return this.mainAppScript.toLowerCase() == path.toLowerCase();
+      else
+        return this.mainAppScript == path;
+    }
+  },
+
+  normalizeName: {
+    value: function(name) {
+      if (this._isMainAppScript(name)) {
+        return this.mainAppScript;
+      }
+
+      return name;
     }
   },
 

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -37,8 +37,8 @@ exports.v8NameToInspectorUrl = function(v8name) {
   return v8name;
 };
 
-exports.inspectorUrlToV8Name = function(url) {
-  var path = url.replace(/^file:\/\//, '');
+exports.inspectorUrlToV8Name = function(url, normalize) {
+  var path = normalize(url.replace(/^file:\/\//, ''));
   if (/^\/[a-zA-Z]:\//.test(path))
     return path.substring(1).replace(/\//g, '\\'); // Windows disk path
   if (/^\//.test(path))

--- a/test/ScriptManager.js
+++ b/test/ScriptManager.js
@@ -4,6 +4,8 @@ var expect = require('chai').expect,
 
 describe('ScriptManager', function() {
   var manager;
+  var realMainAppScript = 'folder/App.js';
+  var mainAppScript = 'folder/app.js';
 
   beforeEach(function() {
     var frontendClientStub = {
@@ -11,6 +13,8 @@ describe('ScriptManager', function() {
     };
     var debuggerClientStub = new EventEmitter();
     manager = new ScriptManager([], frontendClientStub, debuggerClientStub);
+    manager.realMainAppScript = realMainAppScript;
+    manager.mainAppScript = mainAppScript;
   });
 
 
@@ -30,6 +34,27 @@ describe('ScriptManager', function() {
       manager._sources['id'] = 'a-source';
       manager.reset();
       expect(manager.findScriptByID('id')).to.equal(undefined);
+    });
+  });
+
+  describe('normalizeName()', function() {
+    if (process.platform == 'win32') {
+      it('returns case sensitive name for main script on Windows', function() {
+        var name = manager.normalizeName(realMainAppScript);
+        expect(name).to.equal(mainAppScript);
+      });
+    } else {
+      it('returns unchanged name for main script on Linux', function() {
+        var name = manager.normalizeName('folder/app.js');
+        var normalized_name = manager.normalizeName(realMainAppScript);
+        expect(normalized_name).to.equal(realMainAppScript);
+      });
+    }
+
+    it('returns unchanged name for not main scripts', function() {
+      var name = 'folder/app1.js';
+      var normalized_name = manager.normalizeName(name);
+      expect(normalized_name).to.equal(name);
     });
   });
 });

--- a/test/convert.js
+++ b/test/convert.js
@@ -30,22 +30,24 @@ describe('convert', function() {
   });
 
   describe('inspectorUrlToV8Name', function() {
+    function dummyNormalize(name) { return name; }
 
     it('returns filename without path for node.js internal modules', function() {
-      expect(convert.inspectorUrlToV8Name('events.js')).to.equal('events.js');
+      expect(convert.inspectorUrlToV8Name('events.js', dummyNormalize)).to.equal('events.js');
     });
 
     it('converts URL to unix path', function() {
-      expect(convert.inspectorUrlToV8Name('file:///home/user/app.js')).to.equal('/home/user/app.js');
+      expect(convert.inspectorUrlToV8Name('file:///home/user/app.js', dummyNormalize))
+        .to.equal('/home/user/app.js');
     });
 
     it('converts URL to windows disk path', function() {
-      expect(convert.inspectorUrlToV8Name('file:///C:/Users/user/app.js'))
+      expect(convert.inspectorUrlToV8Name('file:///C:/Users/user/app.js', dummyNormalize))
         .to.equal('C:\\Users\\user\\app.js');
     });
 
     it('converts URL to windows UNC', function() {
-      expect(convert.inspectorUrlToV8Name('file://SHARE/user/app.js'))
+      expect(convert.inspectorUrlToV8Name('file://SHARE/user/app.js', dummyNormalize))
         .to.equal('\\\\SHARE\\user\\app.js');
     });
   });


### PR DESCRIPTION
On Windows if we run `node-debug app` and real file name is App.js,
we have two identical files in resources tree (app.js and App.js),
but we can't set breakpoints in App.js.
