### PR TITLE
Avoid serialization of internal properties

### DIFF
--- a/lib/InjectorServer.js
+++ b/lib/InjectorServer.js
@@ -12,11 +12,15 @@ function injectorServer(options) {
   global.process._debugObject = debug;
 
   debug.serializeAndCacheMirror = function(cache, mirror, response) {
-    //get previously cached mirror if existed
+    // Get previously cached mirror if existed
     mirror = resolveCachedMirror(cache, mirror);
 
     var serializer = makeMirrorSerializer(true);
     var body = serializer.serializeValue(mirror);
+
+    // Current serialization doesn't support internal properties refs
+    // Will be fixed after injecting InjectedScript.js
+    delete body.internalProperties;
 
     var refs = {};
     serializer.mirrors_.forEach(function(refMirror) {

--- a/test/fixtures/Commandlet.js
+++ b/test/fixtures/Commandlet.js
@@ -4,10 +4,20 @@ var commands = {
   },
   'log object': function() {
     console.log({ a: 'test' });
+  },
+  'log console': function() {
+    console.log(console);
   }
 };
 
+var buffer = '';
 process.stdin.on('data', function(data) {
-  data = '' + data;
-  if (commands[data]) commands[data]();
+  buffer += data;
+  while(/\n/.test(buffer)) {
+    var parts = buffer.split('\n');
+    var command = parts.splice(0, 1);
+    buffer = parts.join('\n');
+
+    if (commands[command]) commands[command]();
+  }
 });


### PR DESCRIPTION
Current serialization algorithm don't support internal properties refs.
So we can't inspect in console something like this:
`console.log(console)` (tested on 0.11.13)
