### PR TITLE
Fix changelog.sh for Windows

### DIFF
--- a/tools/git-changelog.sh
+++ b/tools/git-changelog.sh
@@ -8,9 +8,7 @@ tmp="$TMPDIR/changelog"
 
 if [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ]; then
   NULL="NUL";
-  # TMP was overriden by Bash (TMP="/tmp") we need to unset it.
-  unset TMP;
-  tmp="$TMP/changelog"
+  tmp="._changelog"
 fi
 
 while [ "$1" != "" ]; do

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -26,10 +26,12 @@ echo --Commit the changes--
 git commit -m "$VERSION" ChangeLog.md package.json
 
 echo --Tag the release--
-tools/git-changelog -l -t "$VERSION" | git tag -a "$TAG" -F-
+tools/git-changelog.sh -l -t "$VERSION" | git tag -a "$TAG" -F-
 
 echo --Push to github--
 git push && git push origin "$TAG"
 
 echo --Publish to npmjs.org--
 npm publish
+
+echo --RELEASED $VERSION--


### PR DESCRIPTION
Previous version doesn't work correctly (it miss first commit message in changelog list).
I can't understand this behavior, but this commit fix it.