### PR TITLE
Make sure to open URL in a webkit browser

### DIFF
--- a/bin/node-debug.js
+++ b/bin/node-debug.js
@@ -5,7 +5,7 @@ var fork = require('child_process').fork;
 var fs = require('fs');
 var path = require('path');
 var util = require('util');
-var open = require('opener');
+var open = require('biased-opener');
 var whichSync = require('which').sync;
 var inspector = require('..');
 
@@ -194,7 +194,17 @@ function openBrowserAndPrintInfo() {
   );
 
   if (!config.options.cli) {
-    open(url);
+    // try to launch the URL in one of those browsers in the defined order
+    // (but if one of them is default browser, then it takes priority)
+    open(url, {
+        preferredBrowsers : ['chrome', 'chromium', 'opera']
+      }, function(err, okMsg) {
+        if (err) {
+           // unable to launch one of preferred browsers for some reason
+           console.log(err.message);
+           console.log('Please open the URL manually in Chrome/Chromium/Opera or similar browser');
+        }
+    });
   }
 
   console.log('Node Inspector is now available from %s', url);

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "strong-data-uri": "~0.1.0",
     "debug": "^1.0",
     "ws": "~0.4.31",
-    "opener": "^1.3.0",
+    "biased-opener": "~0.2.2",
     "yargs": "^1.2.1",
     "which": "^1.0.5",
     "v8-debug": "~0.3.0",


### PR DESCRIPTION
[commit message]

`opener` always opens the URL in the default browser of the user.
It might be annoying for a user whose default browser is Firefox
to have Node Inspector start in Firefox.

This PR makes sure that the Node Inspector URL is opened
either in Chrome, Chromium or Opera (if one of them is the default
browsers, it gets priority). If we can't do that for some reason
(e.g. user has none of them installed), we just display an error
message in the console but do not open the URL in any browser.

---------------------

Hello guys,

This PR is quite small but takes advantage of a couple of modules for detecting available browsers [4, 5], default browser [2, 3], and launching them [1, 4]. I wrote [1] and [2] myself because I couldn't find any module doing the thing that was cross-platform.

Known issues with [1] for now are the following:
- unable to close the opened browser (but you didn't do it before either)
- it doesn't detect when Chromium is installed on Windows (because it depends on [4] which depends on old version of [5]; the bug is fixed in [5]) - but detects Opera and Chrome.

Let me know what do you think about this PR!

Also, I'm looking forward to the reports from as many Linuxes as possible whether

```
npm install -g x-default-browser
x-default-browser
```

correctly reports the default browser (it might not report some exotic browsers, PRs welcome).

Probably it's not a big deal for most of you who have Chrome as a default browser, but it's pretty annoying for me having Firefox as a default :)

[1] https://github.com/jakub-g/biased-opener
[2] https://github.com/jakub-g/x-default-browser
[3] https://github.com/sindresorhus/default-browser-id
[4] https://github.com/benderjs/browser-launcher2
[5] https://github.com/vweevers/win-detect-browsers