### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,19 @@ Just make sure port 8080 is accessible.
 
 Create a JSON-encoded array.  You must escape quote characters when using a command-line option.
 
+#### My options are not being considered
+
+Make sure you put the options before the main script argument.
+
+Right:
+```
+node-debug --hidden=test.js app
+```
+Wrong:
+```
+node-debug app --hidden=test.js
+```
+
 ```sh
 $ node-inspector --hidden='["node_modules/framework"]'
 ```
@@ -337,7 +350,7 @@ $ node-debug --web-host 127.0.0.2 app
 ``` 
 Pass `--option=value` to debugging process:
 ```
-$ node-debug app --option value
+$ node-debug --option value app
 ```
 Start node-inspector to listen on HTTPS:
 ```
@@ -346,6 +359,14 @@ $ node-debug --ssl-key ./ssl/key.pem --ssl-cert ./ssl/cert.pem app
 Ignore breakpoints in files stored in `node_modules` folder or ending in `.test.js`:
 ```
 $ node-debug --hidden node_modules/ --hidden \.test\.js$ app
+```
+Only show files with the word 'test.js' in the path:
+```
+$ node-debug --hidden=^\(?\!.*test\.js.*\) app
+```
+Only show files with the word 'test.js' or 'hello.js' in the path:
+```
+$ node-debug --hidden=^\(?\!\(.*test\.js.*\)\|\(.*hello\.js.*\)\) app
 ```
 Add `--harmony` flag to the node process running the debugged script:
 ```


### PR DESCRIPTION
Add exclusive include to make sure people know how they can include only certain files. This is extremely useful if you're trying to debug a certain file.

I also changed one of the examples on line 340, because the options have to be specific before the main script, or they will not be included.