### PR TITLE
Fix typo

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -94,7 +94,7 @@ var definitions = {
                  'breakpoints in these files will be ignored.\n' +
                  'All paths are interpreted as regular expressions.',
     usage: {
-      '--hidden .*\\.test\\.js$ --hidden node_modules/': 'ignore node_modules directoty' +
+      '--hidden .*\\.test\\.js$ --hidden node_modules/': 'ignore node_modules directory' +
         'and all `*.test.js` files'
     },
     _isNodeInspectorOption: true,
@@ -270,7 +270,7 @@ Config.prototype.showHelp = function(NODE_DEBUG_MODE) {
       inspectorOptions.push(key);
     }
   }, this);
-  
+
   var inspectorPart = color('green', '[node-inspector-options]');
   var optionsPart = color('cyan', '[options]');
   var scriptPart = color('red', '[script [script-arguments]]');
@@ -403,7 +403,7 @@ function checkSslOptions(options) {
 
     path = fs.realpathSync(path);
     if (!fs.existsSync(path)) throw new Error('The file "' + path + '" does not exist');
-    
+
     return path;
   }
 


### PR DESCRIPTION
There was a small typo in config.js. I changed `directoty` to `directory`.