### PR TITLE
Enable latest Node v0.10 on Travis again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - "0.10.33"
+  - "0.10"
   - "0.11.13"


### PR DESCRIPTION
Node v0.10.36 has fixed the debugger regression from 34 & 35, we can start tracking the latest version again.

Note that Node v0.11.15 still does not pass the tests yet.

/cc @3y3 FYI