### PR TITLE
bump glob version, add -sdir option for #498

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ so that sources earlier in this list override later ones.
 | --stack-trace-limit |     | 50      | Number of stack frames to show on a breakpoint.
 | --ssl-key           |     |         | Path to file containing a valid SSL key.
 | --ssl-cert          |     |         | Path to file containing a valid SSL certificate.
+| --sdir              | -s  | false   | glob **/**/* to recurse one extra level of symlinked directories (slower)
 
 ### Usage examples
 

--- a/lib/ScriptFileStorage.js
+++ b/lib/ScriptFileStorage.js
@@ -2,6 +2,8 @@ var fs = require('fs');
 var path = require('path');
 var async = require('async');
 var glob = require('glob');
+var debug = require('debug')('node-inspector:ScriptFileStorage');
+
 
 var MODULE_HEADER = '(function (exports, require, module, __filename, __dirname) { ';
 var MODULE_TRAILER = '\n});';
@@ -13,6 +15,7 @@ var MODULE_WRAP_REGEX = new RegExp(
 
 var CONVENTIONAL_DIRS_PATTERN = '{*.js,lib/**/*.js,node_modules/**/*.js,test/**/*.js}';
 var ALL_JS_PATTERN = '**/*.js';
+var ALL_JS_PATTERN_SDIR = '**/**/*.js'; // glob extra level of symlinked dirs (slower)
 
 function escapeRegex(str) {
   return str.replace(/([/\\.?*()^${}|[\]])/g, '\\$1');
@@ -27,6 +30,7 @@ function ScriptFileStorage(config, scriptManager) {
   config = config || {};
   this._scriptManager = scriptManager;
   this._noPreload = config.preload === false;
+  this.sdir = config.sdir;
 }
 
 var $class = ScriptFileStorage.prototype;
@@ -148,6 +152,7 @@ $class.listScripts = function(rootFolder, pattern, callback) {
   //   { root: rootFolder },
   //    callback
   // );
+  debug('glob: %s %s', pattern, rootFolder);
 
   glob(
     pattern,
@@ -185,7 +190,9 @@ $class._findScriptsOfRunningApp = function(mainScriptFile, callback) {
     [
       this.findApplicationRoot.bind(this, mainScriptFile),
       function(dir, isRoot, cb) {
-        var pattern = isRoot ? ALL_JS_PATTERN : CONVENTIONAL_DIRS_PATTERN;
+        var pattern = isRoot ?
+          (this.sdir ? ALL_JS_PATTERN_SDIR : ALL_JS_PATTERN) :
+          CONVENTIONAL_DIRS_PATTERN;
         this.listScripts(dir, pattern, cb);
       }.bind(this)
     ],
@@ -200,7 +207,9 @@ $class._findScriptsOfStartDirectoryApp = function(startDirectory, callback) {
       if (!result) {
         callback(null, []);
       } else {
-        this.listScripts(startDirectory, ALL_JS_PATTERN, callback);
+        this.listScripts(startDirectory,
+          (this.sdir ? ALL_JS_PATTERN_SDIR : ALL_JS_PATTERN),
+          callback);
       }
     }.bind(this)
   );
@@ -224,11 +233,15 @@ $class.findAllApplicationScripts = function(startDirectory, mainScriptFile, call
     function(err, results) {
       if (err) return callback(err);
 
+      debug('findAllApplicationScripts filtering start');
+
       var files = results[0].concat(results[1]);
       // filter out duplicates and files to hide
       files = files.filter(function(elem, ix, arr) {
         return arr.indexOf(elem) >= ix && !this._scriptManager.isScriptHidden(elem);
       }.bind(this));
+
+      debug('findAllApplicationScripts filtering done.');
 
       return callback(null, files);
     }.bind(this)

--- a/lib/config.js
+++ b/lib/config.js
@@ -141,6 +141,14 @@ var definitions = {
     usage: '--cli',
     _isNodeDebugOption: true,
     default: false
+  },
+  'sdir': {
+    alias: 's',
+    type: 'boolean',
+    description: 'Recurse one extra level of symlinked directories',
+    usage: '--sdir',
+    _isNodeInspectorOption: true,
+    default: false
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "express": "^4.0",
     "serve-favicon": "^2.1.1",
     "async": "~0.9",
-    "glob": "^3.2.1",
+    "glob": "^4.3.5",
     "rc": "~0.5.0",
     "strong-data-uri": "~0.1.0",
     "debug": "^1.0",

--- a/test/config.js
+++ b/test/config.js
@@ -89,6 +89,11 @@ describe('Config', function() {
       expect(config.cli).to.equal(true);
     });
 
+    it('handles --sdir', function() {
+      var config = givenConfigFromArgs('--sdir');
+      expect(config.sdir).to.equal(true);
+    });
+
     function givenConfigFromArgs(argv) {
       return new Config([].concat(argv));
     }
@@ -112,6 +117,7 @@ describe('Config', function() {
       expect(config.debugBrk, 'default debug-brk value').to.equal(false);
       expect(config.nodejs.length, 'default nodejs array is empty').to.equal(0);
       expect(config.cli, 'default cli value').to.equal(false);
+      expect(config.sdir, 'default sdir value').to.equal(false);
     });
 
     it('have expected values in node-debug mode', function() {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,2 @@
 --require chai
+--timeout 5000


### PR DESCRIPTION
see issue #498 
when there are symlinked directories debugger may take minutes to load

the latest version of glob does not search symlinked directories but allowing this is sometimes desireable
( https://github.com/isaacs/node-glob/issues/134 )

using the `*/**/**` pattern, makes at least one extra level of symlinked directories accessible for debugging but is quite a lot slower, so i added a config option to turn this on only when required.

tests are passing, and delays on deep symlinked projects are now acceptable (~5s instead of ~5min).

refs:
- https://github.com/adgad/express-handlebars/commit/803129ed9b325640cc527aefdb5096dda7661355
- https://github.com/ericf/express-handlebars/pull/98