### PR TITLE
Fixed source links not opening within the inspector (partial).

### DIFF
--- a/front-end-node/Overrides.css
+++ b/front-end-node/Overrides.css
@@ -2,3 +2,42 @@
 #tab-general, #general-tab-content { display: none; }
 #tab-overrides, #overrides-tab-content { display: none; }
 #tab-workspace, #workspace-tab-content { display: none; }
+
+/* support file uri links in profiler/console */
+a.profile-node-file, a.console-message-url {
+  pointer-events: none;
+  cursor: default;
+  color: black;
+  text-decoration: none;
+}
+
+span.profile-node-file {
+  margin-top: 1px;
+}
+
+#console-messages span.console-message-url {
+  color: rgb(33%, 33%, 33%) !important;
+  cursor: pointer !important;
+}
+
+#console-messages span.console-message-url:hover {
+  color: rgb(15%, 15%, 15%) !important;
+}
+
+span.profile-node-file {
+  color: rgb(33%, 33%, 33%) !important;
+  cursor: pointer !important;
+}
+
+span.profile-node-file:hover {
+  color: rgb(15%, 15%, 15%) !important;
+}
+
+.data-grid:focus tr.selected .profile-node-file {
+  color: white !important;
+  cursor: pointer !important;
+}
+
+.data-grid:focus tr.selected .profile-node-file:hover {
+  color: rgb(95%, 95%, 95%) !important;
+}

--- a/front-end-node/Overrides.js
+++ b/front-end-node/Overrides.js
@@ -254,8 +254,8 @@ WebInspector.linkifyURLAsNode = function(url, linkText, classes, isExternal, too
 
   a.addEventListener('click',(function(){
     var uri = this.textContent.replace(/\:\d*$/gi,'');
-    if (uri === 'evalmachine.<anonymous>'
-      || (/\[VM\]\sevalmachin…mous\>\s\(\d+\)/gi).test(uri) === true) {
+    if (uri === 'evalmachine.<anonymous>' ||
+      (/\[VM\]\sevalmachin…mous\>\s\(\d+\)/gi).test(uri) === true) {
       return;
     }
     var projects = WebInspector.workspace.projects();

--- a/front-end-node/Overrides.js
+++ b/front-end-node/Overrides.js
@@ -64,7 +64,7 @@ WebInspector._panelDescriptors = function() {
 };
 
 // Patch the expression used as an initial value for a new watch.
-// DevTools' value "\n" breaks the debugger protocol.
+// DevTools' value '\n' breaks the debugger protocol.
 importScript('WatchExpressionsSidebarPane.js');
 WebInspector.WatchExpressionsSection.NewWatchExpression = '\'\'';
 
@@ -239,22 +239,23 @@ WebInspector.linkifyURLAsNode = function(url, linkText, classes, isExternal, too
 {
   if (!linkText)
     linkText = url;
-  classes = (classes ? classes + " " : "");
-  classes += isExternal ? "webkit-html-external-link" : "webkit-html-resource-link";
+  classes = (classes ? classes + ' ' : '');
+  classes += isExternal ? 'webkit-html-external-link' : 'webkit-html-resource-link';
 
-  var a = document.createElement("span");
+  var a = document.createElement('span');
   a.className = classes;
-  if (typeof tooltipText === "undefined")
+  if (typeof tooltipText === 'undefined')
     a.title = linkText;
-  else if (typeof tooltipText !== "string" || tooltipText.length)
+  else if (typeof tooltipText !== 'string' || tooltipText.length)
     a.title = tooltipText;
   a.textContent = linkText.trimMiddle(WebInspector.Linkifier.MaxLengthForDisplayedURLs);
   if (isExternal)
-    a.setAttribute("target", "_blank");
+    a.setAttribute('target', '_blank');
 
   a.addEventListener('click',(function(){
-    var uri = this.textContent.replace(/\:\d*$/gi,"");
-    if (uri === "evalmachine.<anonymous>" || (/\[VM\]\sevalmachin…mous\>\s\(\d+\)/gi).test(uri) === true) {
+    var uri = this.textContent.replace(/\:\d*$/gi,'');
+    if (uri === 'evalmachine.<anonymous>'
+      || (/\[VM\]\sevalmachin…mous\>\s\(\d+\)/gi).test(uri) === true) {
       return;
     }
     var projects = WebInspector.workspace.projects();
@@ -265,7 +266,7 @@ WebInspector.linkifyURLAsNode = function(url, linkText, classes, isExternal, too
       project
         .uiSourceCodes()
         .filter(function (uiSourceCode) {
-          if (uiSourceCode._url === "file://" + uri || uiSourceCode._name === uri) {
+          if (uiSourceCode._url === 'file://' + uri || uiSourceCode._name === uri) {
             results.push(uiSourceCode);
           }
         });
@@ -284,10 +285,10 @@ WebInspector.linkifyURLAsNode = function(url, linkText, classes, isExternal, too
     if (result_sourcecode != null) {
       result_line = parseInt((/\d+$/gi).exec(a.textContent) || 1);
       //TODO: support sourcemaps
-      WebInspector.showPanel("scripts")._showSourceLocation(result_sourcecode, result_line-1);
+      WebInspector.showPanel('scripts')._showSourceLocation(result_sourcecode, result_line-1);
     }
     return false;
   }).bind(a));
 
   return a;
-}
+};


### PR DESCRIPTION
The source links in console and profiler were opening in a new blank window (attempt to load them from filesystem).
This partial fix enables node-inspector to open supported links through embedded CodeMirror (at correct line if detected).

TODO: support sourcemaps, intercepting link creation before linkify function is called to extract data in a proper manner.