### PR TITLE
.travis.yml: drop 0.11, add 0.12 and io.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
   - "0.10"
-  - "0.11.13"
+  - "0.12"
+  - "iojs"


### PR DESCRIPTION
This PR will most likely fail the build, we have two options: either land it to make it clear that Node Inspector is not supported on these versions yet, or keep the PR open until support for io.js & Node v0.12 is landed.

@3y3 Thoughts?
