### PR TITLE
fix #567 unable to start node-debug if default browser check failed

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "strong-data-uri": "~0.1.0",
     "debug": "^1.0",
     "ws": "~0.4.31",
-    "biased-opener": "~0.2.2",
+    "biased-opener": "~0.2.3",
     "yargs": "^1.2.1",
     "which": "^1.0.5",
     "v8-debug": "~0.4.2",


### PR DESCRIPTION
The code of `biased-opener` didn't properly check for error of `x-default-browser` and broke `node-debug` in case where checking for default browser failed for some reason, as in #567

(the fixing commit is https://github.com/jakub-g/biased-opener/commit/72229d498b0aa3716018f449d625413c8b147b05)