### PR TITLE
Changed min Express version to 4.8.0 to avoid sendFile method bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node-debug": "./bin/node-debug.js"
   },
   "dependencies": {
-    "express": "^4.0",
+    "express": "^4.8.0",
     "serve-favicon": "^2.1.1",
     "async": "~0.9",
     "glob": "^4.3.5",


### PR DESCRIPTION
Node-inspector uses the method ServerResponse.sendFile, which does not exist in versions of Express prior to 4.8.0. However, package.json depends on ^4.0.

Closes https://github.com/node-inspector/node-inspector/issues/541 (theoretically ^^)