### PR TITLE
use glob v5.0.3 to follow symlinks and return realpaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,9 @@ Node Inspector supports almost all of the debugging features of DevTools, includ
 
 ## Known Issues
 
-* Automatic preloading of js files to set breakpoints will not work in
-  symlinked directories. This is because the [glob](https://github.com/isaacs/node-glob) module doesn't explore
-  symlinked directories, and it doesn't return "real" paths ([issue](https://github.com/isaacs/node-glob/issues/142).)
-  The workaround is to allow the debugger to load those modules at runtime and then set the breakpoints.
-  Not following symlinks does avoid long startup delays when there are symlink cycles.
+* If there are symlink cycles the [glob](https://github.com/isaacs/node-glob) module may take
+  a long time to return results causing long delays at startup. The workaround is to disable
+  preloading of scripts with `--no-preload`.
 * Be careful about viewing the contents of Buffer objects,
   each byte is displayed as an individual array element;
   for most Buffers this will take too long to render.

--- a/lib/ScriptFileStorage.js
+++ b/lib/ScriptFileStorage.js
@@ -2,6 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var async = require('async');
 var glob = require('glob');
+var debug = require('debug')('node-inspector:ScriptFileStorage');
 
 var MODULE_HEADER = '(function (exports, require, module, __filename, __dirname) { ';
 var MODULE_TRAILER = '\n});';
@@ -149,17 +150,20 @@ $class.listScripts = function(rootFolder, pattern, callback) {
   //    callback
   // );
 
+  debug('glob %s on %s', pattern, rootFolder);
+
   glob(
     pattern,
     {
       cwd: rootFolder,
+      follow: true,
+      realpath: true,
       strict: false
     },
     function(err, result) {
       if (result) {
-        result = result.map(function(relativeUnixPath) {
-          var relativePath = relativeUnixPath.split('/').join(path.sep);
-          return path.join(rootFolder, relativePath);
+        result = result.map(function(unixPath) {
+          return unixPath.split('/').join(path.sep);
         });
       }
 
@@ -170,6 +174,7 @@ $class.listScripts = function(rootFolder, pattern, callback) {
         result: result
       };
 
+      debug('glob returned %s files', err || result.length);
       callback(err, result);
     }.bind(this)
   );
@@ -230,6 +235,7 @@ $class.findAllApplicationScripts = function(startDirectory, mainScriptFile, call
         return arr.indexOf(elem) >= ix && !this._scriptManager.isScriptHidden(elem);
       }.bind(this));
 
+      debug('findAllApplicationScripts returned %s files', files.length);
       return callback(null, files);
     }.bind(this)
   );

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "express": "^4.8.0",
     "serve-favicon": "^2.1.1",
     "async": "~0.9",
-    "glob": "^4.3.5",
+    "glob": "^5.0.3",
     "rc": "~0.5.0",
     "strong-data-uri": "~0.1.0",
     "debug": "^1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "express": "^4.8.0",
     "serve-favicon": "^2.1.1",
     "async": "~0.9",
-    "glob": "^5.0.3",
+    "glob": "^5.0.5",
     "rc": "~0.5.0",
     "strong-data-uri": "~0.1.0",
     "debug": "^1.0",


### PR DESCRIPTION
The glob module now has options to return realpaths and follow symlinks. With glob v5.0.3. this feature is usable with node-inspector.

Preloaded scripts in symlinked directories now show up properly in the inspector source tree and breakpoints work, fixing issue #370.

f.w.i.w. i also added a little debug tracing in ScriptFileStorage. e.g. to trace during tests do:

    DEBUG=node-inspector:ScriptFileStorage npm test

Fix #370