### PR TITLE
Fix console in debug-brk mode

### DIFF
--- a/lib/ConsoleAgent.js
+++ b/lib/ConsoleAgent.js
@@ -11,7 +11,6 @@ var convert = require('./convert');
 function ConsoleAgent(config, session) {
   this._noInject = config.inject === false;
   this._injected = false;
-  this._consoleEnabled = false;
   this._debuggerClient = session.debuggerClient;
   this._frontendClient = session.frontendClient;
   this._injectorClient = session.injectorClient;
@@ -38,8 +37,6 @@ ConsoleAgent.prototype._inject = function(injected) {
       this._injected = !error;
 
       if (error) return this._frontendClient.sendLogToConsole('error', error.message || error);
-
-      if (this._consoleEnabled) this._debuggerClient.request('Console.enable');
     }.bind(this)
   );
 };
@@ -72,11 +69,6 @@ ConsoleAgent.prototype._translateCommandToInjection = function(commandNames) {
       this._debuggerClient.request('Console.' + command, params, done);
     };
   }, this);
-};
-
-ConsoleAgent.prototype.enable = function(params, done) {
-  this._consoleEnabled = true;
-  done();
 };
 
 ConsoleAgent.prototype.injection = function(require, debug, options) {
@@ -173,7 +165,6 @@ ConsoleAgent.prototype.injection = function(require, debug, options) {
   debug.register('Console.messagesCleared', debug.commandToEvent);
   debug.register('Console.messageRepeatCountUpdated', debug.commandToEvent);
 
-  debug.register('Console.enable', wrapConsole);
   debug.register('Console.clearMessages', function(request, response) {
     clearMessages();
     debug.command('Console.messagesCleared');
@@ -196,6 +187,8 @@ ConsoleAgent.prototype.injection = function(require, debug, options) {
   });
 
   debug.on('close', unwrapConsole);
+  
+  wrapConsole();
 };
 
 module.exports.ConsoleAgent = ConsoleAgent;

--- a/lib/FrontendCommandHandler.js
+++ b/lib/FrontendCommandHandler.js
@@ -52,6 +52,7 @@ FrontendCommandHandler.prototype = {
     this._registerNoopCommands(
       'Network.enable',
       'Network.setCacheDisabled',
+      'Console.enable',
       'Console.setMonitoringXHREnabled',
       'Console.addInspectedHeapObject',
       'Database.enable',


### PR DESCRIPTION
On node 0.12 we can't use any custom commands (like 'Console.enable') if we stopped on first line.
This is a bug that can be fixed only in node source code.

Here I delete complicated console wrapping - we don't need to send 'Console.enable' to wrap console now.

This doesn't fixes initial problem. For example on 0.12 we can't get snapshot if we paused on first line. We need to send `continue` before using any custom command.

@bajtos , please review.