### PR TITLE
[WIP] Alternative Network tab implementation

### DIFF
--- a/front-end-node/injections-inspector.json
+++ b/front-end-node/injections-inspector.json
@@ -1,11 +1,11 @@
 [
   { "name": "node", "type": "autostart" },
+  { "name": "node/network", "type": "autostart" },
   { "name": "node/settings", "type": "autostart" },
   { "name": "node/sources", "type": "autostart" },
   { "name": "node/console", "type": "autostart" },
   { "name": "node/main", "type": "autostart" },
   { "name": "audits", "type": "exclude"},
-  { "name": "network", "type": "exclude"},
   { "name": "elements", "type": "exclude"},
   { "name": "timeline", "type": "exclude"},
   { "name": "resources", "type": "exclude"}

--- a/front-end-node/inspector.json
+++ b/front-end-node/inspector.json
@@ -1,6 +1,7 @@
 [
     { "name": "node", "type": "autostart" },
     { "name": "node/profiler", "type": "autostart" },
+    { "name": "node/network", "type": "autostart" },
     { "name": "node/settings", "type": "autostart" },
     { "name": "node/sources", "type": "autostart" },
     { "name": "node/console", "type": "autostart" },
@@ -20,6 +21,7 @@
     { "name": "sources" },
     { "name": "profiler" },
     { "name": "console" },
+    { "name": "network" },
     { "name": "source_frame" },
     { "name": "settings" },
     { "name": "devices" },

--- a/front-end-node/network/NetworkPanel.js
+++ b/front-end-node/network/NetworkPanel.js
@@ -1,0 +1,17 @@
+/*jshint browser:true, nonew:false*/
+/*global WebInspector:true, NetworkAgent:true*/
+WebInspector.NetworkLogView.prototype.orig_toggleRecordButton =
+  WebInspector.NetworkLogView.prototype._toggleRecordButton;
+
+WebInspector.NetworkLogView.prototype._toggleRecordButton = function(toggled) {
+  this.orig_toggleRecordButton.apply(this, arguments);
+
+  if (!window.NetworkAgent) return;
+  NetworkAgent._setCapturingEnabled(this._recordButton.toggled());
+};
+
+WebInspector.NetworkPanel._instance()._networkLogView.addEventListener(
+  WebInspector.NetworkLogView.EventTypes.ViewCleared,
+  function() {
+    NetworkAgent._clearCapturedData();
+  });

--- a/front-end-node/network/NetworkPanel.js
+++ b/front-end-node/network/NetworkPanel.js
@@ -15,3 +15,6 @@ WebInspector.NetworkPanel._instance()._networkLogView.addEventListener(
   function() {
     NetworkAgent._clearCapturedData();
   });
+
+WebInspector.NetworkPanel._instance()._networkLogView._preserveLogCheckbox.setVisible(false);
+WebInspector.NetworkPanel._instance()._networkLogView._disableCacheCheckbox.setVisible(false);

--- a/front-end-node/network/module.json
+++ b/front-end-node/network/module.json
@@ -1,0 +1,8 @@
+{
+    "dependencies": [
+        "network"
+    ],
+    "scripts": [
+        "NetworkPanel.js"
+    ]
+}

--- a/front-end-node/protocol.json
+++ b/front-end-node/protocol.json
@@ -10,6 +10,24 @@
                 "description": "Open console window"
             }
         ]
+      },
+      {
+        "domain": "Network",
+        "types": [],
+        "commands": [
+            {
+                "name": "_clearCapturedData",
+                "description": "Removes all saved requests data"
+            },
+            {
+                "name": "_setCapturingEnabled",
+                "parameters": [
+                    { "name": "enabled", "type": "boolean", "description": "True, if capturing enabled" }
+                ],
+                "description": "Disables capturing of http requests"
+            }
+        ],
+        "events": []
       }
     ]
 }

--- a/front-end/InspectorBackendCommands.js
+++ b/front-end/InspectorBackendCommands.js
@@ -121,6 +121,8 @@ InspectorBackend.registerCommand("Network.canEmulateNetworkConditions", [], ["re
 InspectorBackend.registerCommand("Network.emulateNetworkConditions", [{"name": "offline", "type": "boolean", "optional": false}, {"name": "latency", "type": "number", "optional": false}, {"name": "downloadThroughput", "type": "number", "optional": false}, {"name": "uploadThroughput", "type": "number", "optional": false}], [], false);
 InspectorBackend.registerCommand("Network.setCacheDisabled", [{"name": "cacheDisabled", "type": "boolean", "optional": false}], [], false);
 InspectorBackend.registerCommand("Network.loadResourceForFrontend", [{"name": "frameId", "type": "string", "optional": false}, {"name": "url", "type": "string", "optional": false}, {"name": "requestHeaders", "type": "object", "optional": true}], ["statusCode", "responseHeaders", "content"], false);
+InspectorBackend.registerCommand("Network._clearCapturedData", [], [], false);
+InspectorBackend.registerCommand("Network._setCapturingEnabled", [{"name": "enabled", "type": "boolean", "optional": false}], [], false);
 InspectorBackend.registerEvent("Network.requestWillBeSent", ["requestId", "frameId", "loaderId", "documentURL", "request", "timestamp", "initiator", "redirectResponse", "type"]);
 InspectorBackend.registerEvent("Network.requestServedFromCache", ["requestId"]);
 InspectorBackend.registerEvent("Network.responseReceived", ["requestId", "frameId", "loaderId", "timestamp", "type", "response"]);

--- a/front-end/platform/utilities.js
+++ b/front-end/platform/utilities.js
@@ -314,6 +314,42 @@ String.prototype.isDigitAt = function(index)
 }
 
 /**
+ * @return {string}
+ */
+String.prototype.toBase64 = function()
+{
+    /**
+     * @param {number} b
+     * @return {number}
+     */
+    function encodeBits(b)
+    {
+        return b < 26 ? b + 65 : b < 52 ? b + 71 : b < 62 ? b - 4 : b === 62 ? 43 : b === 63 ? 47 : 65;
+    }
+    var encoder = new TextEncoder();
+    var data = encoder.encode(this.toString());
+    var n = data.length;
+    var encoded = "";
+    if (n === 0)
+        return encoded;
+    var shift;
+    var v = 0;
+    for (var i = 0; i < n; i++) {
+        shift = i % 3;
+        v |= data[i] << (16 >>> shift & 24);
+        if (shift === 2) {
+            encoded += String.fromCharCode(encodeBits(v >>> 18 & 63), encodeBits(v >>> 12 & 63), encodeBits(v >>> 6 & 63), encodeBits(v & 63));
+            v = 0;
+        }
+    }
+    if (shift === 0)
+        encoded += String.fromCharCode(encodeBits(v >>> 18 & 63), encodeBits(v >>> 12 & 63), 61, 61);
+    else if (shift === 1)
+        encoded += String.fromCharCode(encodeBits(v >>> 18 & 63), encodeBits(v >>> 12 & 63), encodeBits(v >>> 6 & 63), 61);
+    return encoded;
+}
+
+/**
  * @param {string} a
  * @param {string} b
  * @return {number}

--- a/front-end/sdk/NetworkRequest.js
+++ b/front-end/sdk/NetworkRequest.js
@@ -899,9 +899,12 @@ WebInspector.NetworkRequest.prototype = {
     asDataURL: function()
     {
         var content = this._content;
-        if (!this._contentEncoded)
-            content = window.btoa(content);
-        return WebInspector.Resource.contentAsDataURL(content, this.mimeType, true);
+        var charset = null;
+        if (!this._contentEncoded) {
+            content = content.toBase64();
+            charset = "utf-8";
+        }
+        return WebInspector.Resource.contentAsDataURL(content, this.mimeType, true, charset);
     },
 
     _innerRequestContent: function()

--- a/front-end/sdk/Resource.js
+++ b/front-end/sdk/Resource.js
@@ -68,15 +68,16 @@ WebInspector.Resource.Events = {
  * @param {?string} content
  * @param {string} mimeType
  * @param {boolean} contentEncoded
+ * @param {?string=} charset
  * @return {?string}
  */
-WebInspector.Resource.contentAsDataURL = function(content, mimeType, contentEncoded)
+WebInspector.Resource.contentAsDataURL = function(content, mimeType, contentEncoded, charset)
 {
     const maxDataUrlSize = 1024 * 1024;
     if (content === null || content.length > maxDataUrlSize)
         return null;
 
-    return "data:" + mimeType + (contentEncoded ? ";base64," : ",") + content;
+    return "data:" + mimeType + (charset ? ";charset=" + charset : "") + (contentEncoded ? ";base64" : "") + "," + content;
 }
 
 /**

--- a/lib/Injections/NetworkAgent.js
+++ b/lib/Injections/NetworkAgent.js
@@ -1,0 +1,396 @@
+// This function will be injected into the target process.
+module.exports = function(require, debug, options) {
+  var http = require('http'),
+    https = require('https'),
+    EventEmitter = require('events').EventEmitter;
+
+  var addRequest = http.Agent.prototype.addRequest,
+      onSocket = http.ClientRequest.prototype.onSocket;
+
+  var lastRequestId = 0,
+      lastConnectionId = 0;
+
+  function timestamp() {
+    return Date.now() / 1000000;
+  }
+
+  function Timing() {
+    this._hrtime = process.hrtime();
+
+    this.json = {
+      requestTime: Date.now() / 1000,
+      proxyStart: -1,
+      proxyEnd: -1,
+      dnsStart: -1,
+      dnsEnd: -1,
+      connectStart: -1,
+      connectEnd: -1,
+      sslStart: -1,
+      sslEnd: -1,
+      serviceWorkerFetchStart: -1,
+      serviceWorkerFetchReady: -1,
+      serviceWorkerFetchEnd: -1,
+      sendStart: -1,
+      sendEnd: -1,
+      receiveHeadersEnd: -1
+    };
+  }
+
+  [
+    'proxyStart', 'proxyEnd',
+    'dnsStart', 'dnsEnd',
+    'connectStart', 'connectEnd',
+    'sslStart', 'sslEnd',
+    'serviceWorkerFetchStart', 'serviceWorkerFetchReady', 'serviceWorkerFetchEnd',
+    'sendStart', 'sendEnd',
+    'receiveHeadersEnd'
+  ].forEach(function(method) {
+    Timing.prototype[method] = function() {
+      var diff = process.hrtime(this._hrtime);
+      this.json[method] = diff[0] * 1e3 + diff[1] / 1e6;
+      return this;
+    };
+  });
+
+  function getStackTrace() {
+    var backup = Error.prepareStackTrace;
+
+    Error.prepareStackTrace = function(_, stack) { return stack; };
+    // We want to trim stack trace to display user caller function.
+    // We wait what request will be sent by one of functions in `callers` list.
+    // If function exists in stack trace, his length will be great than 0
+    // If there is no known caller func we sent full stack trace
+    var callers = [handleHttpRequest, http.request, http.get, https.request, https.get],
+      error,
+      stack;
+
+    while (!stack && callers.length) {
+      error = new Error();
+      Error.captureStackTrace(error, callers.pop());
+      if (error.stack.length) stack = error.stack;
+    }
+
+    if (!stack) stack = new Error().stack;
+
+    Error.prepareStackTrace = backup;
+
+    return stack.reduce(function(stack, frame) {
+      var fileName = frame.getFileName();
+
+      fileName = debug.convert.v8NameToInspectorUrl(fileName);
+
+      var url = fileName || frame.getEvalOrigin();
+
+      stack.push({
+        url: url,
+        functionName: frame.getFunctionName(),
+        lineNumber: frame.getLineNumber(),
+        columnNumber: frame.getColumnNumber()
+      });
+
+      return stack;
+    }, []);
+  }
+
+  function renderHeaders(request) {
+    var headers = request._headers;
+    if (!headers) return {};
+
+    return Object.keys(headers).reduce(function renderHeader(result, key) {
+      var headerName = request._headerNames[key];
+      result[headerName] = '' + headers[key];
+      return result;
+    }, {});
+  }
+
+  function getCorrectHeaders(response) {
+    return Object.keys(response.headers).reduce(function correctHeader(result, key) {
+      var value = response.headers[key];
+
+      if (Array.isArray(value))
+        value = value.join('\n');
+
+      result[key] = '' + value;
+      return result;
+    }, {});
+  }
+
+  function getStatusText(response) {
+    return response.statusMessage || http.STATUS_CODES[response.statusCode] || '?';
+  }
+
+  function restoreHeadersText(response) {
+    var headers = response.rawHeaders;
+    // TODO: there is no `rawHeaders` in node 0.10.*
+    // We can wrap parser to find raw headers, but it's not so useful to see original string
+    // So, maybe won't fix
+    if (!headers) return;
+
+    var headersPrefix = [
+      'HTTP/' + response.httpVersion,
+      response.statusCode,
+      response.statusMessage
+    ].join(' ');
+
+    var joinedHeaders = [headersPrefix];
+    while (headers.length)
+      joinedHeaders.push(headers.splice(-2).join(': '));
+
+    return joinedHeaders.join('\r\n') + '\r\n\r\n';
+  }
+
+  function getMimeType(response) {
+    if (typeof response.headers['content-type'] != 'string')
+      return 'text/plain';
+
+    return response.headers['content-type'].split(';')[0];
+  }
+
+  function constructRequestInfo(request) {
+    var requestId = request.__inspector_ID__;
+    var timestamp = request.__inspector_timing__.json.requestTime;
+    var url = request.__inspector_url__;
+
+    return {
+      requestId: requestId,
+      loaderId: process.pid + '',
+      documentURL: url,
+      type: 'XHR',
+      request: {
+        headers: renderHeaders(request),
+        method: request.method,
+        postData: '',
+        url: url
+      },
+      timestamp: timestamp,
+      initiator: {
+        stackTrace: getStackTrace(),
+        type: 'script'
+      }
+    };
+  }
+
+  function constructResponseInfo(response) {
+    var request = response.req;
+
+    return {
+      requestId: request.__inspector_ID__,
+      loaderId: process.pid + '',
+      timestamp: timestamp(),
+      type: 'XHR',
+      response: {
+        url: request.__inspector_url__,
+        status: response.statusCode,
+        statusText: getStatusText(response),
+        headers: getCorrectHeaders(response),
+        mimeType: getMimeType(response),
+        connectionReused: request.shouldKeepAlive,
+        connectionId: request.connection.__inspector_ID__,
+        encodedDataLength: -1,
+        fromDiskCache: false,
+        fromServiceWorker: false,
+        timing: request.__inspector_timing__.json,
+        headersText: restoreHeadersText(response),
+        requestHeaders: renderHeaders(request),
+        requestHeadersText: request._header
+      }
+    };
+  }
+
+  function constructFailureInfo(request, err, canceled) {
+    // NOTE: If there is no other `error` listeners
+    // handling of `error` event changes program behavior
+    // We won't to destroy app on each failed request,
+    // but we need to notify user about unhandled `error` event.
+    var unhandled = err && EventEmitter.listenerCount(request, 'error') === 0;
+    var errorText = (unhandled ? '(unhandled) ' : '') + (err && err.code);
+    return {
+      requestId: request.__inspector_ID__,
+      timestamp: timestamp(),
+      type: 'XHR',
+      errorText: errorText,
+      canceled: canceled
+    };
+  }
+
+  function handleHttpRequest(options) {
+    var timing = new Timing();
+    var protocol = options.protocol || this.agent.protocol || 'http:',
+      host = options.host,
+      port = options.port,
+      path = this.path;
+
+    this.__inspector_timing__ = timing;
+    this.__inspector_ID__ = '' + lastRequestId++;
+    this.__inspector_url__ = protocol + '//' + host + ':' + port + path;
+
+    var requestInfo = constructRequestInfo(this);
+
+    this.once('socket', handleSocket.bind(this, requestInfo));
+    this.once('response', handleHttpResponse);
+    this.once('error', handleFailure.bind(this, requestInfo));
+    handleRequestData.call(this, requestInfo);
+    handleAbort.call(this, requestInfo);
+
+    timing.dnsStart();
+  }
+
+  function handleRequestData(requestInfo) {
+    var oldWrite = this.write;
+
+    this.write = function(chunk) {
+      requestInfo.request.postData += chunk || '';
+      return oldWrite.apply(this, arguments);
+    };
+  }
+
+  function sendRequestWillBeSent(requestInfo) {
+    if (requestInfo.handled) return;
+    requestInfo.handled = true;
+
+    debug.emitEvent('Network.requestWillBeSent', requestInfo);
+    debug.emitEvent('Network._requestWillBeSent', {
+      requestId: requestInfo.requestId
+    });
+  }
+
+  function handleSocket(requestInfo, socket) {
+    socket.__inspector_ID__ = socket.__inspector_ID__ || '' + lastConnectionId++;
+
+    this.__inspector_timing__.dnsEnd().connectStart();
+
+    socket.once('connect', function() {
+      this.__inspector_timing__.connectEnd().sendStart();
+      setImmediate(this.__inspector_timing__.sendEnd.bind(this.__inspector_timing__));
+    }.bind(this));
+
+    sendRequestWillBeSent(requestInfo);
+  }
+
+  function handleAbort(requestInfo) {
+    var abort = this.abort;
+    this.abort = function() {
+      var result = abort.apply(this, arguments);
+      handleFailure.call(this, requestInfo);
+      return result;
+    };
+  }
+
+  function handleFailure(requestInfo, err) {
+    sendRequestWillBeSent(requestInfo);
+
+    var failureInfo = constructFailureInfo(this, err, !err);
+    debug.emitEvent('Network.loadingFailed', failureInfo);
+    debug.emitEvent('Network._loadingFailed', {
+      requestId: this.__inspector_ID__
+    });
+  }
+
+  function handleHttpResponse(response) {
+    var request = response.req;
+    request.__inspector_timing__.receiveHeadersEnd();
+
+    // NOTE: If there is no other `response` listeners
+    // handling of `response` event changes program behavior
+    // Without our listener all data will be dumped, but we pause data by our listener.
+    // Most simple solution here to `resume` data stream, instead of dump it,
+    // otherwise we'll never get a data.
+    if (EventEmitter.listenerCount(request, 'response') === 0)
+      response.resume();
+
+    var requestId = request.__inspector_ID__,
+      responseInfo = constructResponseInfo(response),
+      dataLength = 0;
+
+    debug.emitEvent('Network.responseReceived', responseInfo);
+
+    var push = response.push;
+
+    response.push = function(chunk) {
+      if (chunk) {
+        dataLength += chunk.length;
+
+        debug.emitEvent('Network._dataReceived', {
+          requestId: requestId,
+          data: chunk + ''
+        });
+
+        debug.emitEvent('Network.dataReceived', {
+          requestId: requestId,
+          timestamp: timestamp(),
+          dataLength: chunk.length,
+          encodedDataLength: chunk.length
+        });
+      }
+
+      return push.apply(this, arguments);
+    };
+
+    response.once('end', function() {
+      response.push = push;
+
+      debug.emitEvent('Network._loadingFinished', {
+        requestId: requestId
+      });
+
+      debug.emitEvent('Network.loadingFinished', {
+        requestId: requestId,
+        timestamp: timestamp(),
+        encodedDataLength: dataLength
+      });
+    });
+  }
+
+  debug.registerEvent('Network.requestWillBeSent');
+  debug.registerEvent('Network._requestWillBeSent');
+  debug.registerEvent('Network.responseReceived');
+  debug.registerEvent('Network.dataReceived');
+  debug.registerEvent('Network._dataReceived');
+  debug.registerEvent('Network.loadingFinished');
+  debug.registerEvent('Network._loadingFinished');
+  debug.registerEvent('Network.loadingFailed');
+  debug.registerEvent('Network._loadingFailed');
+
+  wrapHttpRequests();
+  debug.once('close', unwrapHttpRequests);
+
+  function wrapHttpRequests() {
+    http.Agent.prototype.addRequest = function(req, options) {
+      // NOTE: For node 0.10.*
+      // We can't redefine options itself, this changes arguments
+      var _options = options;
+
+      // Legacy API: addRequest(req, host, port, path)
+      if (typeof _options === 'string') {
+        _options = {
+          host: options,
+          port: arguments[2],
+          path: arguments[3]
+        };
+      }
+      handleHttpRequest.call(req, _options);
+
+      return addRequest.apply(this, arguments);
+    };
+
+    http.ClientRequest.prototype.onSocket = function(socket) {
+      var handledByAddRequest = this.__inspector_ID__ !== undefined,
+          isUnixSocket = this.socketPath;
+
+      if (!handledByAddRequest && !isUnixSocket) {
+        handleHttpRequest.call(this, {
+          host: this.socket._host,
+          port: '80', // We can't find real port here
+          path: this.path
+        });
+      }
+
+      return onSocket.apply(this, arguments);
+    };
+  }
+
+  function unwrapHttpRequests() {
+    http.Agent.prototype.addRequest = addRequest;
+    http.ClientRequest.prototype.onSocket = onSocket;
+  }
+};

--- a/lib/InjectorClient.js
+++ b/lib/InjectorClient.js
@@ -132,7 +132,8 @@ InjectorClient.prototype._pause = function() {
 InjectorClient.prototype._inject = function(TARGET_FRAME) {
   var injectorServerPath = JSON.stringify(require.resolve('./InjectorServer'));
   var options = {
-    'v8-debug': require.resolve('v8-debug')
+    'v8-debug': require.resolve('v8-debug'),
+    'convert': require.resolve('./convert')
   };
   var injection = '(require(\'module\')._load(' + injectorServerPath + '))' +
                   '(' + JSON.stringify(options) + ')';

--- a/lib/InjectorServer.js
+++ b/lib/InjectorServer.js
@@ -11,6 +11,8 @@ function injectorServer(options) {
   global.process._require = require;
   global.process._debugObject = debug;
 
+  debug.convert = require(options['convert']);
+
   debug.serializeAndCacheMirror = function(cache, mirror, response) {
     // Get previously cached mirror if existed
     mirror = resolveCachedMirror(cache, mirror);

--- a/lib/NetworkAgent.js
+++ b/lib/NetworkAgent.js
@@ -1,9 +1,142 @@
 var fs = require('fs');
 var path = require('path');
 var dataUri = require('strong-data-uri');
+var inherits = require('util').inherits;
+var EventEmitter = require('events').EventEmitter;
 
-function NetworkAgent() {
+var injection = require('./Injections/NetworkAgent');
+
+function NetworkAgent(config, session) {
+  this._noInject = config.inject === false;
+  this._debuggerClient = session.debuggerClient;
+  this._frontendClient = session.frontendClient;
+  this._injectorClient = session.injectorClient;
+
+  this._capturingEnabled = true;
+  this._dataStorage = {};
+
+  if (!this._noInject) this._injectorClient.on('inject', this._inject.bind(this));
 }
+
+NetworkAgent.prototype._inject = function(injected) {
+  if (!injected) return;
+
+  this._translateEventToFrontend(
+    'requestWillBeSent',
+    'responseReceived',
+    'dataReceived',
+    'loadingFinished',
+    'loadingFailed'
+  );
+
+  this._handleEvent('_requestWillBeSent', this._registerInDataStorage.bind(this));
+  this._handleEvent('_dataReceived', this._saveToDataStorage.bind(this));
+  this._handleEvent('_loadingFinished', this._constructRequestData.bind(this));
+  this._handleEvent('_loadingFailed', this._dumpRequestData.bind(this));
+
+  this._injectorClient.injection(
+    injection,
+    {},
+    function(error, result) {
+      this._injected = !error;
+
+      if (error) return this._frontendClient.sendLogToConsole('error', error.message || error);
+    }.bind(this)
+  );
+};
+
+/**
+ * @param {...string} eventNames
+*/
+NetworkAgent.prototype._translateEventToFrontend = function(eventNames) {
+  Array.prototype.forEach.call(arguments, function(event) {
+    event = 'Network.' + event;
+    this._debuggerClient.registerDebuggerEventHandlers(event);
+    this._debuggerClient.on(event, function(message) {
+      this._frontendClient.sendEvent(event, message);
+    }.bind(this));
+  }, this);
+};
+
+NetworkAgent.prototype._handleEvent = function(event, handle) {
+  event = 'Network.' + event;
+  this._debuggerClient.registerDebuggerEventHandlers(event);
+  this._debuggerClient.on(event, handle);
+};
+
+NetworkAgent.prototype._registerInDataStorage = function(message) {
+  if (!this._capturingEnabled) return;
+
+  var requestId = message.requestId;
+  if (this._dataStorage[requestId])
+    throw new Error('Data storage for request #' + requestId + ' already exists');
+
+  this._dataStorage[requestId] = new ResponseData();
+};
+
+NetworkAgent.prototype._saveToDataStorage = function(message) {
+  if (!this._capturingEnabled) return;
+
+  var responseData = this._dataStorage[message.requestId];
+  if (!responseData) return;
+
+  responseData.push(message.data);
+};
+
+NetworkAgent.prototype._constructRequestData = function(message) {
+  if (!this._capturingEnabled) return;
+
+  var responseData = this._dataStorage[message.requestId];
+  if (!responseData) return;
+
+  responseData.finish();
+};
+
+NetworkAgent.prototype._dumpRequestData = function(message) {
+  if (!this._capturingEnabled) return;
+
+  var responseData = this._dataStorage[message.requestId];
+  if (!responseData) return;
+
+  responseData.dump();
+};
+
+NetworkAgent.prototype.getResponseBody = function(params, done) {
+  var responseData = this._dataStorage[params.requestId];
+
+  if (!responseData)
+    return done(new Error('There is no data for request #' + params.requestId));
+
+  var result = {
+    base64Encoded: false,
+    body: null
+  };
+
+  if (!responseData.finished) {
+    responseData.once('finish', function(data) {
+      result.body = data;
+      done(null, result);
+    });
+  } else {
+    process.nextTick(function() {
+      result.body = responseData.data;
+      done(null, result);
+    });
+  }
+};
+
+NetworkAgent.prototype._setCapturingEnabled = function(params, done) {
+  this._capturingEnabled = params.enabled;
+  done();
+};
+
+NetworkAgent.prototype._clearCapturedData = function(params, done) {
+  Object.keys(this._dataStorage).forEach(function(key) {
+    this._dataStorage[key].dispose();
+  }, this);
+  this._dataStorage = {};
+  done();
+};
 
 NetworkAgent.prototype.loadResourceForFrontend = function(params, done) {
   if (/^data:/.test(params.url)) {
@@ -61,6 +194,38 @@ function loadFileResource(params, done) {
 
 NetworkAgent.prototype.setUserAgentOverride = function(params, done) {
   done(null, {});
+};
+
+function ResponseData(id) {
+  this.data = [];
+  this.finished = false;
+}
+inherits(ResponseData, EventEmitter);
+
+ResponseData.prototype.finish = function() {
+  if (this.finished) return;
+
+  this.data = this.data.join('');
+  this.finished = true;
+  this.emit('finish', this.data);
+};
+
+ResponseData.prototype.dump = function() {
+  if (this.finished) return;
+
+  this.data = '';
+  this.finished = true;
+  this.emit('finish', this.data);
+};
+
+ResponseData.prototype.push = function(chunk) {
+  this.data.push(chunk);
+};
+
+ResponseData.prototype.dispose = function() {
+  if (!this.finished) this.dump();
+
+  this.removeAllListeners();
 };
 
 exports.NetworkAgent = NetworkAgent;

--- a/package.json
+++ b/package.json
@@ -39,8 +39,9 @@
     "yargs": "^3.9.0"
   },
   "devDependencies": {
+    "promise": "^7.0.3",
     "mocha": "^1.21",
-    "chai": "^1.9",
+    "chai": "^2.1",
     "jshint": "^2.4.4",
     "fs-extra": "~0.8.1"
   },

--- a/test/NetworkAgent.js
+++ b/test/NetworkAgent.js
@@ -1,10 +1,18 @@
 var expect = require('chai').expect,
+    Promise = require('promise'),
+    launcher = require('./helpers/launcher.js'),
+    InjectorClient = require('../lib/InjectorClient').InjectorClient,
     NetworkAgent = require('../lib/NetworkAgent.js').NetworkAgent;
+
+var commandlet,
+    debuggerClient,
+    frontendClient,
+    networkAgent;
 
 describe('NetworkAgent', function() {
   describe('loadResourceForFrontend', function() {
     it('should load data URLs', function(done) {
-      var agent = new NetworkAgent();
+      var agent = new NetworkAgent({ inject: false }, {});
       agent.loadResourceForFrontend(
         {
           url: 'data:text/plain;base64,aGVsbG8gd29ybGQ='
@@ -17,4 +25,251 @@ describe('NetworkAgent', function() {
       );
     });
   });
+
+  describe('HTTP request wrapper', function() {
+    var requestWillBeSent,
+        responseReceived,
+        dataReceived,
+        loadingFinished;
+
+    before(initializeNetwork);
+    before(function() {
+      requestWillBeSent = new Promise(function(resolve, reject) {
+        frontendClient.once('Network.requestWillBeSent', resolve);
+      });
+      responseReceived = new Promise(function(resolve, reject) {
+        frontendClient.once('Network.responseReceived', resolve);
+      });
+      dataReceived = new Promise(function(resolve, reject) {
+        frontendClient.once('Network.dataReceived', resolve);
+      });
+      loadingFinished = new Promise(function(resolve, reject) {
+        frontendClient.once('Network.loadingFinished', resolve);
+      });
+
+      commandlet.stdin.write('send GET request\n');
+    });
+
+    it('should emit `requestWillBeSent` event', function(done) {
+      requestWillBeSent.then(function(message) {
+        expect(message.documentURL).to.match(/^http:\/\/127\.0\.0\.1:\d+\/page\?a=b$/);
+
+        var host = /^http:\/\/(127\.0\.0\.1:\d+).*$/.exec(message.documentURL)[1];
+
+        expect(message).to.have.property('requestId').that.is.a('string');
+        expect(message).to.have.property('loaderId').that.is.a('string');
+        expect(message).to.have.property('timestamp').that.is.a('number');
+        expect(message.type).to.equal('XHR');
+        expect(message.request).to.deep.equal({
+          headers: {
+            Host: host,
+            'X-REQUEST-HEADER': 'X-REQUEST-DATA'
+          },
+          method: 'GET',
+          postData: 'Body for GET request? Really?!',
+          url: message.documentURL
+        });
+        expect(message.initiator).to.include.keys('type', 'stackTrace');
+      })
+      .then(done)
+      .catch(done);
+    });
+
+    it('should emit `responseReceived` event', function(done) {
+      responseReceived.then(function(message) {
+        expect(message).to.have.property('requestId').that.is.a('string');
+        expect(message).to.have.property('loaderId').that.is.a('string');
+        expect(message).to.have.property('timestamp').that.is.a('number');
+        expect(message.type).to.equal('XHR');
+        containKeys(message.response, {
+          status: 200,
+          statusText: 'OK',
+          mimeType: 'text/plain',
+          connectionId: '0',
+          encodedDataLength: -1,
+          fromDiskCache: false,
+          fromServiceWorker: false
+        });
+        expect(message.response).to.contain.keys([
+          'timing',
+          'headers',
+          'requestHeaders',
+          'requestHeadersText',
+          'connectionReused'
+        ]);
+        expect(message.response.url).to.match(/127\.0\.0\.1:\d+\/page\?a=b/);
+
+        var timings = ['proxy', 'dns', 'connect', 'ssl', 'serviceWorkerFetch', 'send']
+          .map(function(name) {
+            return [name + 'Start', name + 'End'];
+          });
+
+        expect(message.response.timing).to.have.all.keys(Array.prototype.concat.apply([
+          'requestTime',
+          'serviceWorkerFetchReady',
+          'receiveHeadersEnd'
+        ], timings));
+
+        timings.forEach(function(timing) {
+          var start = timing[0],
+              end = timing[1];
+          expect(message.response.timing[start], start + ' less than or equal to ' + end)
+            .to.be.at.most(message.response.timing[end]);
+        });
+      })
+      .then(done)
+      .catch(done);
+    });
+
+    it('should emit `dataReceived` event', function(done) {
+      dataReceived.then(function(message) {
+        expect(message).to.have.property('requestId').that.is.a('string');
+        expect(message).to.have.property('timestamp').that.is.a('number');
+        expect(message.dataLength).to.be.above(0);
+        expect(message.encodedDataLength).to.be.above(0);
+      })
+      .then(done)
+      .catch(done);
+    });
+
+    it('should emit `loadingFinished` event', function(done) {
+      loadingFinished.then(function(message) {
+        expect(message).to.have.property('requestId').that.is.a('string');
+        expect(message).to.have.property('timestamp').that.is.a('number');
+        expect(message.encodedDataLength).to.be.equal(13);
+      })
+      .then(done)
+      .catch(done);
+    });
+
+    it('should capture response data', function(done) {
+      loadingFinished.then(function(message) {
+        var getBody = Promise.denodeify(networkAgent.getResponseBody);
+        return getBody.call(networkAgent, {
+          requestId: message.requestId
+        });
+      }).then(function(result) {
+        expect(result).to.deep.equal({
+          body: 'RESPONSE DATA',
+          base64Encoded: false
+        });
+      })
+      .then(done)
+      .catch(done);
+    });
+
+    it('should clean captured data', function() {
+      expect(Object.keys(networkAgent._dataStorage).length).to.be.equal(1);
+      networkAgent._clearCapturedData({}, function() {});
+      expect(Object.keys(networkAgent._dataStorage).length).to.be.equal(0);
+    });
+
+    it('should stop data capturing', function(done) {
+      expect(Object.keys(networkAgent._dataStorage).length).to.be.equal(0);
+      networkAgent._setCapturingEnabled({
+        enabled: false
+      }, function() {});
+      frontendClient.once('Network.loadingFinished', function() {
+        expect(Object.keys(networkAgent._dataStorage).length).to.be.equal(0);
+        networkAgent._setCapturingEnabled({ enabled: true }, done);
+      });
+
+      commandlet.stdin.write('send GET request\n');
+    });
+
+    it('should handle failure of request', function(done) {
+      frontendClient.once('Network.loadingFailed', function(message) {
+        containKeys(message, {
+          errorText: 'ECONNRESET',
+          type: 'XHR'
+        });
+        networkAgent.getResponseBody({requestId: message.requestId}, function(error, result) {
+          containKeys(result, {
+            base64Encoded: false,
+            body: ''
+          });
+          done();
+        });
+      });
+
+      commandlet.stdin.write('send GET request with handled failure\n');
+    });
+
+    it('should handle unhandled failure of request', function(done) {
+      frontendClient.once('Network.loadingFailed', function(message) {
+        containKeys(message, {
+          errorText: '(unhandled) ECONNRESET',
+          type: 'XHR'
+        });
+        done();
+      });
+
+      commandlet.stdin.write('send GET request with unhandled failure\n');
+    });
+
+    it('should handle failure of request to unexisted server', function(done) {
+      this.timeout(5000);
+      frontendClient.once('Network.loadingFailed', function(message) {
+        containKeys(message, {
+          errorText: 'ECONNREFUSED',
+          type: 'XHR'
+        });
+        done();
+      });
+
+      commandlet.stdin.write('send GET request to unexisted server\n');
+    });
+
+    it('should handle aborted request (on creation step)', function(done) {
+      frontendClient.once('Network.loadingFailed', function(message) {
+        containKeys(message, {
+          type: 'XHR',
+          canceled: true
+        });
+        done();
+      });
+
+      commandlet.stdin.write('send GET request aborted on creation step\n');
+    });
+
+    it('should handle aborted request (on response step)', function(done) {
+      frontendClient.once('Network.loadingFailed', function(message) {
+        containKeys(message, {
+          type: 'XHR',
+          canceled: true
+        });
+        done();
+      });
+
+      commandlet.stdin.write('send GET request aborted on response step\n');
+    });
+  });
+
+  function containKeys(obj, keys) {
+    Object.keys(keys).forEach(function(key) {
+      expect(obj[key], key + ' is equal to ' + keys[key]).to.be.equal(keys[key]);
+    });
+  }
+
+  function initializeNetwork(done) {
+    launcher.runCommandlet(true, function(child, session) {
+      commandlet = child;
+      debuggerClient = session.debuggerClient;
+      frontendClient = session.frontendClient;
+
+      commandlet.stdout.pipe(process.stdout);
+
+      var injectorClient = new InjectorClient({}, session);
+      session.injectorClient = injectorClient;
+
+      networkAgent = new NetworkAgent({}, session);
+
+      injectorClient.once('inject', function(injected) {
+        if (injected) debuggerClient.request('continue', null, done);
+      });
+      injectorClient.once('error', done);
+
+      injectorClient.inject();
+    });
+  }
 });

--- a/test/fixtures/Commandlet.js
+++ b/test/fixtures/Commandlet.js
@@ -1,4 +1,6 @@
 /*jshint debug:true */
+var http = require('http');
+
 var commands = {
   'log simple text': function() {
     console.log('test');
@@ -14,8 +16,132 @@ var commands = {
   },
   'pause': function() {
     debugger;
+  },
+  'send GET request': function() {
+    startServer({
+        res: {
+          statusCode: 200,
+          headers: {
+            'X-RESPONSE-HEADER': 'X-RESPONSE-DATA'
+          },
+          data: 'RESPONSE DATA'
+        }
+      },
+      function sendRequest(server) {
+        http.request({
+          method: 'GET',
+          host: '127.0.0.1',
+          path: '/page?a=b',
+          port: server.address().port,
+          headers: {
+            'X-REQUEST-HEADER': 'X-REQUEST-DATA'
+          }
+        })
+        .end('Body for GET request? Really?!');
+      }
+    );
+  },
+  'send GET request with unhandled failure': function() {
+    startServer({
+        res: {},
+        destroy: true
+      },
+      function sendRequest(server) {
+        http.request({
+          method: 'GET',
+          host: '127.0.0.1',
+          path: '/page?a=b',
+          port: server.address().port
+        }).end();
+      }
+    );
+  },
+  'send GET request with handled failure': function() {
+    startServer({
+        res: {},
+        destroy: true
+      },
+      function sendRequest(server) {
+        http.request({
+          method: 'GET',
+          host: '127.0.0.1',
+          path: '/page?a=b',
+          port: server.address().port
+        })
+        .once('error', function() {/*noop*/})
+        .end();
+      }
+    );
+  },
+  'send GET request to unexisted server': function() {
+    http.request({
+      method: 'GET',
+      host: '127.0.0.2',
+      path: '/page?a=b',
+      port: '80'
+    })
+    .once('error', function() {/*noop*/})
+    .end();
+  },
+  'send GET request aborted on creation step': function() {
+    startServer({
+        res: {
+          statusCode: 200
+        }
+      },
+      function sendRequest(server) {
+        var req = http.request({
+          method: 'GET',
+          host: '127.0.0.1',
+          path: '/page?a=b',
+          port: server.address().port
+        });
+        req.end();
+        req.abort();
+      }
+    );
+  },
+  'send GET request aborted on response step': function() {
+    startServer({
+        res: {
+          statusCode: 200
+        }
+      },
+      function sendRequest(server) {
+        var req = http.request({
+          method: 'GET',
+          host: '127.0.0.1',
+          path: '/page?a=b',
+          port: server.address().port
+        }).on('response', function(res) {
+          res.req.abort();
+        }).end();
+      }
+    );
   }
 };
+
+function startServer(options, callback) {
+  var server = http.createServer(function(req, res) {
+    res.statusCode = options.res.statusCode;
+
+    // set headers
+    if (options.res.headers)
+      Object.keys(options.res.headers).forEach(function(key) {
+        res.setHeader(key, options.res.headers[key]);
+      });
+
+    if (options.destroy) {
+      res.socket.destroy();
+    } else {
+      res.end(options.res.data);
+    }
+
+    server.close();
+  }).listen(0, function() {
+    callback(server);
+  });
+}
 
 var buffer = '';
 process.stdin.on('data', function(data) {


### PR DESCRIPTION
@jkrems , thanks to your experience in #655 I added full network tab implementation.
Here I solve some problems of your pr:
- We can wrap code in `--debug` and `--debug-brk` mode
- We wrap only one function
- We send finished requests to frontend
- Added different identifiers for `requestId`, `connectionId`, `loaderId`.
- We collect stack trace closest to func called by user
- POST data captured

What is implemented:
- Basic http request support
- Request timings
- Request data capturing and cleaning (we store data in node-inspector)
- Backported `String.prototype.toBase64` from latest DevTools. This solves problem with inspection of data with non ascii caracters

What doesn't solved in this pr:
- [TODO](https://github.com/node-inspector/node-inspector/blob/master/lib/FrontendCommandHandler.js#L48-L51) not fixed. So we can't use `XHR breakpoint` section in source panel.
- I don't know that happens if anyone will use not default encoding in `req.write`
- I don't test keep alive requests
- Not implemented `Network + Console` behavior.