### PR TITLE
Fix inline sourcemaps path in node 0.10.x

### DIFF
--- a/lib/ScriptManager.js
+++ b/lib/ScriptManager.js
@@ -3,6 +3,7 @@ var events = require('events'),
     async = require('async'),
     debug = require('debug')('node-inspector:ScriptManager'),
     dataUri = require('strong-data-uri'),
+    pathIsAbsolute = require('path-is-absolute'),
     convert = require('./convert.js');
 
 // see Blink inspector > ContentSearchUtils.cpp > findMagicComment()
@@ -240,7 +241,7 @@ ScriptManager.prototype = Object.create(events.EventEmitter.prototype, {
         // Documentation says what source maps can contain absolute paths,
         // but DevTools strictly expects relative paths.
         sourceMap.sources = sourceMap.sources.map(function(source) {
-          if (!path.isAbsolute(source)) return source;
+          if (!pathIsAbsolute(source)) return source;
 
           return path.relative(scriptOrigin, source);
         });

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "debug": "^2.2.0",
     "express": "^4.12.3",
     "glob": "^5.0.5",
+    "path-is-absolute": "^1.0.0",
     "rc": "^1.0.1",
     "semver": "^4.3.4",
     "serve-favicon": "^2.1.1",


### PR DESCRIPTION
`path.isAbsolute` is not available in node 0.10.x. when an inline sourcemap is found, node-inspector throws with:

```
/usr/local/lib/node_modules/node-inspector/lib/ScriptManager.js:243
          if (!path.isAbsolute(source)) return source;
                    ^
TypeError: Object #<Object> has no method 'isAbsolute'
    at /usr/local/lib/node_modules/node-inspector/lib/ScriptManager.js:243:21
    at Array.map (native)
    at fixAbsoluteSourcePaths (/usr/local/lib/node_modules/node-inspector/lib/ScriptManager.js:242:47)
    at EventEmitter.Object.create._checkSourceMapIssues.value (/usr/local/lib/node_modules/node-inspector/lib/ScriptManager.js:236:7)
    at EventEmitter.Object.create._checkInlineSourceMap.value (/usr/local/lib/node_modules/node-inspector/lib/ScriptManager.js:225:12)
    at EventEmitter.onGetSourceMapUrlReturn (/usr/local/lib/node_modules/node-inspector/lib/ScriptManager.js:200:18)
    at EventEmitter.Object.create._parseSourceMapUrlFromScriptSource.value (/usr/local/lib/node_modules/node-inspector/lib/ScriptManager.js:344:7)
    at fn (/usr/local/lib/node_modules/node-inspector/node_modules/async/lib/async.js:638:34)
    at Object._onImmediate (/usr/local/lib/node_modules/node-inspector/node_modules/async/lib/async.js:554:34)
    at processImmediate [as _immediateCallback] (timers.js:354:15)
```