### PR TITLE
Implementation of HTTP Chrome endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 var url = require('url');
 
 exports.buildInspectorUrl = buildInspectorUrl;
+exports.buildWebSocketUrl = buildWebSocketUrl;
 
 /**
  * Build a URL for loading inspector UI in the browser.
@@ -17,6 +18,25 @@ function buildInspectorUrl(inspectorHost, inspectorPort, debugPort, fileToShow, 
     port: inspectorPort,
     pathname: '/',
     search: '?ws=' + host + ':' + inspectorPort + '&port=' + debugPort
+  };
+
+  return url.format(parts);
+}
+
+/**
+ * Build a URL for the WebSocket endpoint.
+ * @param {string|undefined} inspectorHost as configured via --web-host
+ * @param {number} inspectorPort as configured via --web-port
+ * @param {number} debugPort as configured via --debug in the debugged app
+ */
+function buildWebSocketUrl(inspectorHost, inspectorPort, debugPort, fileToShow, isSecure) {
+  var parts = {
+    protocol: isSecure ? 'wss:' : 'ws:',
+    hostname: inspectorHost == '0.0.0.0' ? '127.0.0.1' : inspectorHost,
+    port: inspectorPort,
+    pathname: '/',
+    search: '?port=' + debugPort,
+    slashes: true
   };
 
   return url.format(parts);

--- a/lib/debug-server.js
+++ b/lib/debug-server.js
@@ -9,7 +9,8 @@ var http = require('http'),
     favicon = require('serve-favicon'),
     WebSocketServer = require('ws').Server,
     Session = require('./session'),
-    buildUrl = require('../index.js').buildInspectorUrl,
+    buildInspectorUrl = require('../index.js').buildInspectorUrl,
+    buildWebSocketUrl = require('../index.js').buildWebSocketUrl,
     OVERRIDES = path.join(__dirname, '../front-end-node'),
     WEBROOT = path.join(__dirname, '../front-end');
 
@@ -17,8 +18,7 @@ function debugAction(req, res) {
   if (!req.query.ws) {
     var urlParts = req.headers.host.split(':'),
       debugPort = this._config.debugPort;
-
-    var newUrl = buildUrl(urlParts[0], urlParts[1], debugPort, null, this._isHTTPS);
+    var newUrl = buildInspectorUrl(urlParts[0], urlParts[1], debugPort, null, this._isHTTPS);
     return res.redirect(newUrl);
   }
   res.sendFile(path.join(WEBROOT, 'inspector.html'));
@@ -30,6 +30,18 @@ function redirectToRoot(req, res) {
 
 function inspectorJson(req, res) {
   res.sendFile(path.join(OVERRIDES, 'inspector.json'));
+}
+
+function jsonAction(req, res) {
+  res.json({
+   'description': 'Node.js app (powered by node-inspector)',
+   'devtoolsFrontendUrl': this.address().url,
+   'id': process.pid,
+   'title': process.title ||'',
+   'type': 'page',
+   'url': '',
+   'webSocketDebuggerUrl': this.wsAddress().url
+  });
 }
 
 function handleWebSocketConnection(socket) {
@@ -73,6 +85,7 @@ DebugServer.prototype.start = function(options) {
   app.get('/', debugAction.bind(this));
   app.get('/debug', redirectToRoot);
   app.get('/inspector.json', inspectorJson);
+  app.get('/json', jsonAction.bind(this));
   app.use('/node', express.static(OVERRIDES));
   app.use(express.static(WEBROOT));
 
@@ -105,7 +118,14 @@ DebugServer.prototype.close = function() {
 DebugServer.prototype.address = function() {
   var address = this._httpServer.address();
   var config = this._config;
-  address.url = buildUrl(config.webHost, address.port, config.debugPort, null, this._isHTTPS);
+  address.url = buildInspectorUrl(config.webHost, address.port, config.debugPort, null, this._isHTTPS);
+  return address;
+};
+
+DebugServer.prototype.wsAddress = function() {
+  var address = this._httpServer.address();
+  var config = this._config;
+  address.url = buildWebSocketUrl(config.webHost, address.port, config.debugPort, null, this._isHTTPS);
   return address;
 };
 

--- a/lib/debug-server.js
+++ b/lib/debug-server.js
@@ -44,6 +44,16 @@ function jsonAction(req, res) {
   });
 }
 
+function jsonVersionAction(req, res) {
+  res.json({
+    'browser': 'Node ' + process.version,
+    'protocol-version': '1.1',
+    'user-agent': 'Node ' + process.version,
+    // webKit-version is a dummy value as it's used to match compatible DevTools front-ends
+    'webKit-version': '537.36 (@181352)'
+  });
+}
+
 function handleWebSocketConnection(socket) {
   var debugPort = this._getDebuggerPort(socket.upgradeReq.url);
   this._createSession(debugPort, socket);
@@ -86,6 +96,7 @@ DebugServer.prototype.start = function(options) {
   app.get('/debug', redirectToRoot);
   app.get('/inspector.json', inspectorJson);
   app.get('/json', jsonAction.bind(this));
+  app.get('/json/version', jsonVersionAction.bind(this));
   app.use('/node', express.static(OVERRIDES));
   app.use(express.static(WEBROOT));
 

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@ var util = require('util'),
 var index = require('../index');
 
 describe('index', function() {
-  describe('build_url', function() {
+  describe('buildInspectorUrl', function() {
     it('should build an http URL', function() {
       var url = index.buildInspectorUrl(
         'example.com',
@@ -27,4 +27,29 @@ describe('index', function() {
       expect(url).to.equal('https://example.com:2223/?ws=example.com:2223&port=7863');
     });
   });
+
+  describe('buildWebSocketUrl', function() {
+    it('should build an ws URL', function() {
+      var url = index.buildWebSocketUrl(
+        'example.com',
+        '2223',
+        '7863',
+        null,
+        false
+      );
+      expect(url).to.equal('ws://example.com:2223/?port=7863');
+    });
+
+    it('should build an wss URL', function() {
+      var url = index.buildWebSocketUrl(
+        'example.com',
+        '2223',
+        '7863',
+        null,
+        true
+      );
+      expect(url).to.equal('wss://example.com:2223/?port=7863');
+    });
+  });
+
 });


### PR DESCRIPTION
This is first stab on an implementation of #684, that provides two new HTTP endpoints ```/json``` and ```/json/version```

``process.id`` is used as the unique identifier for the debugging target, as it's unique and consistent as long the process is running.v