### PR TITLE
JSON endpoints /json and /json/list should return a JSON array

### DIFF
--- a/lib/debug-server.js
+++ b/lib/debug-server.js
@@ -38,7 +38,7 @@ function emptyJson(req, res) {
 }
 
 function jsonAction(req, res) {
-  res.json({
+  res.json([{
    'description': 'Node.js app (powered by node-inspector)',
    'devtoolsFrontendUrl': this.address().url,
    'id': process.pid,
@@ -46,7 +46,7 @@ function jsonAction(req, res) {
    'type': 'page',
    'url': '',
    'webSocketDebuggerUrl': this.wsAddress().url
-  });
+  }]);
 }
 
 function jsonVersionAction(req, res) {
@@ -106,6 +106,7 @@ DebugServer.prototype.start = function(options) {
 
   // Json handshake
   app.get('/json', jsonAction.bind(this));
+  app.get('/json/list', jsonAction.bind(this));
   app.get('/json/version', jsonVersionAction.bind(this));
 
   // Dynamically generated front-end content


### PR DESCRIPTION
This enables interop with third-party debugging clients like
- chrome-repl from the chrome-remote-interface NodeJS module
- Kite and JsSlime for Emacs
- and more

In future this could be used to have multiple NodeJS processes
register with a single node-inspector process, which can then
advertise all these debuggable processes as "tabs" in the array.

This change improves on pull request #689, adding a /json/list
endpoint which should return the same data as the /json endpoint.