### PR TITLE
Fix css issue with debugger window cut off #699

### DIFF
--- a/front-end/inspectorCommon.css
+++ b/front-end/inspectorCommon.css
@@ -102,6 +102,8 @@ body /deep/ .vbox {
     display: flex;
     flex-direction: column !important;
     position: relative;
+    min-width: 0;
+    min-height: 0;
 }
 
 body /deep/ .flex-auto {


### PR DESCRIPTION
There is a bug in Chrome 44 that makes Node Inspector front-end unusable. This fix, suggested in #699 appears to fix the issue.