### PR TITLE
make compatible with iojs 3.2.x and later

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "v8-debug": "~0.5.0",
     "v8-profiler": "~5.2.4",
     "which": "^1.1.1",
-    "ws": "^0.7.1",
+    "ws": "^0.8.0",
     "yargs": "^3.9.0"
   },
   "devDependencies": {


### PR DESCRIPTION
to fix issue #716 update dependency with new version of `ws` library, that use updated `utf-8-validatie` library. so it is now installs well
OS: UBUNTU 14.04.3 64bit 
iojs: 3.2