### PR TITLE
Fix #695 - Calling unexposed function

### DIFF
--- a/front-end/treeoutline.js
+++ b/front-end/treeoutline.js
@@ -940,8 +940,8 @@ TreeElement.prototype.traversePreviousTreeElement = function(skipUnrevealed, don
 TreeElement.prototype.isEventWithinDisclosureTriangle = function(event)
 {
     // FIXME: We should not use getComputedStyle(). For that we need to get rid of using ::before for disclosure triangle. (http://webk.it/74446) 
-    var paddingLeftValue = window.getComputedStyle(this._listItemNode).getPropertyValue("padding-left");
-    var computedLeftPadding = paddingLeftValue ? parseInt(paddingLeftValue) : 0;
+    var paddingLeftValue = window.getComputedStyle(this._listItemNode).paddingLeft;
+    var computedLeftPadding = parseFloat(paddingLeftValue, 10);
     var left = this._listItemNode.totalOffsetLeft() + computedLeftPadding;
     return event.pageX >= left && event.pageX <= left + this.arrowToggleWidth && this.hasChildren;
 }


### PR DESCRIPTION
Using same code as Chromium team:
https://codereview.chromium.org/690893002/diff/1/Source/devtools/front_end/ui/treeoutline.js