### PR TITLE
Huge Startup Time Improvement!!

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,13 @@ $ node-inspector --hidden='["node_modules/framework"]'
 
 Note that the array items are interpreted as regular expressions.
 
+#### How do I ignore files so that they are not even loaded ?
+You can use glob notation with ```---ignore```. For example you could ignore all `node_modules` and the `client/` with the following: 
+
+```sh
+$ node-inspector --ignore "**/node_modules/**" --ignore "client/**"
+```
+
 #### UI doesn't load or doesn't work and refresh didn't help
 
 Make sure that you have adblock disabled as well as any other content blocking scripts and plugins.
@@ -169,7 +176,9 @@ When you are done cleaning up, hit refresh in the browser.
 
 #### Node Inspector takes a long time to start up.
 
-Try setting --no-preload to true. This option disables searching disk for *.js at startup.
+Try setting ```--ignore "**/node_modules/**"``` to avoid loading the node_modules/ directories.  
+
+If that does not work try setting --no-preload to true. This option disables searching disk for *.js at startup.
 Code will still be loaded into Node Inspector at runtime, as modules are required.
 
 #### How do I debug Mocha unit-tests?
@@ -310,6 +319,7 @@ so that sources earlier in this list override later ones.
 | **node-inspector**
 | --save-live-edit    |     | false   | Save live edit changes to disk (update the edited files).
 | --preload           |     | true    | Preload *.js files. You can disable this option<br/>to speed up the startup.
+| --ignore            |     | []      | Array of files to ignore from loading. You can use this to speed up the startup while maintaining the ability to set breakpoints.
 | --inject            |     | true    | Enable injection of debugger extensions into the debugged process. It's possible disable only part of injections using subkeys `--no-inject.network`. Allowed keys : `network`, `profiles`, `console`.
 | --hidden            |     | []      | Array of files to hide from the UI,<br/>breakpoints in these files will be ignored.<br/>All paths are interpreted as regular expressions.
 | --stack-trace-limit |     | 50      | Number of stack frames to show on a breakpoint.
@@ -353,6 +363,10 @@ Ignore breakpoints in files stored in `node_modules` folder or ending in `.test.
 ```
 $ node-debug --hidden node_modules/ --hidden \.test\.js$ app
 ```
+Ignore `node_modules` during loading
+```
+$ node-debug --ignore "**/node_modules/**"
+```
 Add `--harmony` flag to the node process running the debugged script:
 ```
 $ node-debug --nodejs --harmony app
@@ -373,6 +387,7 @@ Use dashed option names in RC files. Sample config file:
   "save-live-edit": true,
   "preload": false,
   "hidden": ["\.test\.js$", "node_modules/"],
+  "ignore": "**/node_modules/**",
   "nodejs": ["--harmony"],
   "stack-trace-limit": 50,
   "ssl-key": "./ssl/key.pem",

--- a/lib/ScriptFileStorage.js
+++ b/lib/ScriptFileStorage.js
@@ -26,6 +26,8 @@ function escapeRegex(str) {
  */
 function ScriptFileStorage(config, session) {
   config = config || {};
+
+  this._ignore = config.ignore;
   this._scriptManager = session.scriptManager;
   this._noPreload = config.preload === false;
 }
@@ -158,12 +160,14 @@ $class.listScripts = function(rootFolder, pattern, callback) {
   //    callback
   // );
 
-  debug('glob %s on %s', pattern, rootFolder);
+  ignore = this._ignore;
+  debug('glob %s on %s ignoring %s', pattern, rootFolder, ignore);
 
   glob(
     pattern,
     {
       cwd: rootFolder,
+      ignore: ignore,
       follow: true,
       realpath: true,
       strict: false

--- a/lib/ScriptFileStorage.js
+++ b/lib/ScriptFileStorage.js
@@ -160,7 +160,7 @@ $class.listScripts = function(rootFolder, pattern, callback) {
   //    callback
   // );
 
-  ignore = this._ignore;
+  var ignore = this._ignore;
   debug('glob %s on %s ignoring %s', pattern, rootFolder, ignore);
 
   glob(

--- a/lib/config.js
+++ b/lib/config.js
@@ -111,6 +111,17 @@ var definitions = {
     _isNodeInspectorOption: true,
     default: []
   },
+  'ignore': {
+    type: 'string',
+    description: 'Array of files to ignore during loading.' +
+               '  All paths are interpreted as globs.',
+    usage: {
+      '--ignore "client/**" --ignore "node_modules/**"': 'ignore node_modules directory' +
+      ' and the client directory files'
+    },
+    _isNodeInspectorOption: true,
+    default: []
+  },
   'stack-trace-limit': {
     type: 'number',
     description: 'Number of stack frames to show on a breakpoint.',
@@ -402,9 +413,14 @@ function normalizeOptions(options) {
   });
 
   checkHiddenOption(normalizedOptions);
+  checkIgnoreOption(normalizedOptions);
   checkSslOptions(normalizedOptions);
 
   return normalizedOptions;
+}
+
+function checkIgnoreOption(options) {
+  options.ignore = [].concat(options.ignore || []);
 }
 
 function checkHiddenOption(options) {

--- a/test/ScriptFileStorage.js
+++ b/test/ScriptFileStorage.js
@@ -211,6 +211,21 @@ describe('ScriptFileStorage', function() {
     );
   });
 
+  it('excludes files that are ignored', function(done) {
+    var expectedFiles = givenTempFiles('app.js', 'mod.js').slice(0, 1);
+    storage = createScriptFileStorage({ignore: 'mod.js'});
+    storage.findAllApplicationScripts(
+      TEMP_DIR,
+      path.join(TEMP_DIR, 'app.js'),
+      function(err, files) {
+        if (err) throw err;
+        expect(files.map(relativeToTemp))
+          .to.have.members(expectedFiles.map(relativeToTemp));
+        expect(files).to.have.length(expectedFiles.length);
+        done();
+      }
+    );
+  });
 
   it('disables preloading files', function(done) {
     givenTempFiles('app.js', 'mod.js');

--- a/test/config.js
+++ b/test/config.js
@@ -59,6 +59,12 @@ describe('Config', function() {
       expect(config.hidden[0]).to.satisfy(util.isRegExp);
     });
 
+    it('handles --ignore', function() {
+      var config = givenConfigFromArgs('--ignore="abc"');
+      expect(config.ignore).to.satisfy(util.isArray);
+      expect(config.ignore.length).to.equal(1);
+    });
+
     it('handles --stack-trace-limit', function() {
       var config = givenConfigFromArgs('--stack-trace-limit=60');
       expect(config.stackTraceLimit).to.equal(60);
@@ -117,6 +123,8 @@ describe('Config', function() {
       expect(config.preload, 'default preload value').to.equal(true);
       expect(config.hidden, 'default hidden value is array').to.satisfy(util.isArray);
       expect(config.hidden.length, 'default hidden array is empty').to.equal(0);
+      expect(config.ignore, 'default ignore value is array').to.satisfy(util.isArray);
+      expect(config.ignore.length, 'default ignore array is empty').to.equal(0);
       expect(config.stackTraceLimit, 'default stack-trace-limit value').to.equal(50);
       expect(config.nodejs, 'default nodejs value is array').to.satisfy(util.isArray);
       expect(config.debugBrk, 'default debug-brk value').to.equal(false);


### PR DESCRIPTION
I have added a new option `--ignore` that is somewhere in the middle of `--hidden` and `--no-preload`. Instead of hiding directories and files as `--hidden` does `--ignore` will avoid loading them all together. 

I saw the need for this because I had very slow startup times. Which lead me to `--no-preload`, but you cannot attach breakpoints to your files until they have been loaded. Which is less than ideal. 

I did not use `--hidden` because it uses RegExp and the ignore option in glob accepts glob syntax.
### Example - Ignore all node modules.
```
$ node-debug --ignore "**/node_modules/**" server/server.js
```
This makes startup load time insignificant while maintaining all meaningful debugging ability.
