### PR TITLE
Added check on startup to prevent trying to load directories

### DIFF
--- a/bin/node-debug.js
+++ b/bin/node-debug.js
@@ -156,7 +156,7 @@ function formatNodeInspectorError(err) {
 
 function startDebuggedProcess(callback) {
   var script = path.resolve(process.cwd(), config.subproc.script);
-  if (!fs.existsSync(script)) {
+  if (!fs.existsSync(script) || fs.lstatSync(script).isDirectory()) {
     try {
       script = whichSync(config.subproc.script);
       script = checkWinCmdFiles(script);


### PR DESCRIPTION
As per title. For example, having a folder in your project named 'grunt' prevents you from being able to debug grunt tasks. The current code just checks to see if the path exists using fs.existsSync, however this is true in the case of a directory, but then the debugger will crap out because it can't load it. I've added an extra check to make sure that the file is also not a directory.