### PR TITLE
New option to exclude preload files and rewriting ScriptFileStorage.listScripts

### DIFF
--- a/lib/ScriptFileStorage.js
+++ b/lib/ScriptFileStorage.js
@@ -28,6 +28,7 @@ function ScriptFileStorage(config, session) {
   config = config || {};
   this._scriptManager = session.scriptManager;
   this._noPreload = config.preload === false;
+  this._preloadExclude = config.preloadExclude||[];
 }
 
 var $class = ScriptFileStorage.prototype;
@@ -144,48 +145,78 @@ $class._isApplicationRoot = function(folder, callback) {
  * @param {function(Object, Array.<string>?)} callback
  */
 $class.listScripts = function(rootFolder, pattern, callback) {
-  var last = this._lastList;
+  var last = this._lastList,
+      that = this;
+
   if (last && last.rootFolder == rootFolder && last.pattern == pattern) {
     process.nextTick(function() { callback(last.error, last.result); });
     return;
   }
 
-  // This simpler solution unfortunately does not work on windows
-  // see https://github.com/isaacs/node-glob/pull/68
-  // glob(
-  //   '**/*.js',
-  //   { root: rootFolder },
-  //    callback
-  // );
 
   debug('glob %s on %s', pattern, rootFolder);
 
-  glob(
-    pattern,
-    {
-      cwd: rootFolder,
-      follow: true,
-      realpath: true,
-      strict: false
-    },
-    function(err, result) {
-      if (result) {
-        result = result.map(function(unixPath) {
-          return unixPath.split('/').join(path.sep);
+  var preloadExcluded = function(file){
+    if (!that._preloadExclude.length) return false;
+    return that._preloadExclude.some(function(regexp){
+      return regexp.test(file);
+    });
+  }
+
+  var walk = function(dir, done) {
+    var results = [];
+    fs.readdir(dir, function(err, list) {
+      if (err) return done(err);
+      var pending = list.length;
+      if (!pending) return done(null, results);
+      list.forEach(function(file) {
+        file = path.resolve(dir, file);
+        if (preloadExcluded(file)) {
+          if (!--pending) done(null, results);
+          return;
+        };
+        fs.stat(file, function(err, stat) {
+
+          if (stat && 
+              stat.isDirectory()) {
+            walk(file, function(err, res) {
+              results = results.concat(res);
+              if (!--pending) done(null, results);
+            });
+          } else {
+            if (/\.js$/.test(file)) {
+              results.push(file);
+            };
+            if (!--pending) done(null, results);
+          }
+
         });
-      }
+      });
+    });
+  };
 
-      this._lastList = {
-        rootFolder: rootFolder,
-        pattern: pattern,
-        error: err,
-        result: result
-      };
+  walk(rootFolder, function(err, result){
 
-      debug('glob returned %s files', err || result.length);
-      callback(err, result);
-    }.bind(this)
-  );
+    var end_time = new Date().getTime();
+
+    if (result) {
+      result = result.map(function(unixPath) {
+        return unixPath.split('/').join(path.sep);
+      });
+    }
+
+    that._lastList = {
+      rootFolder: rootFolder,
+      pattern: pattern,
+      error: err,
+      result: result
+    };
+
+    debug('glob returned %s files', err || result.length);
+    callback(err, result);
+
+  });
+  
 };
 
 $class._findScriptsOfRunningApp = function(mainScriptFile, callback) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -77,6 +77,16 @@ var definitions = {
     _isNodeInspectorOption: true,
     default: true
   },
+  'preload-exclude': {
+    type: 'string',
+    description: 'Array of files not to preload.' +
+                  'All paths are interpreted as regular expressions.',
+    usage: {
+      '--preload-exclude': '.*\\/node_modules\\/.*'
+    },
+    _isNodeInspectorOption: true,
+    default: []
+  },
   'inject': {
     description: 'Enable/disable injection of debugger extensions into the debugged process.\n' +
                '  It`s posiible to disable only part of injections using subkeys.\n' +
@@ -401,10 +411,18 @@ function normalizeOptions(options) {
     normalizedOptions[camelKey] = options[key];
   });
 
+  checkPreloadExcludeOption(normalizedOptions);
   checkHiddenOption(normalizedOptions);
   checkSslOptions(normalizedOptions);
 
   return normalizedOptions;
+}
+
+function checkPreloadExcludeOption(options) {
+  function toRegExp(string) {
+    return new RegExp(string, 'i');
+  }
+  options.preloadExclude = [].concat(options.preloadExclude || []).map(toRegExp);  
 }
 
 function checkHiddenOption(options) {


### PR DESCRIPTION
I have added a new option `--preload-exclude`.  Sometimes I don't want  `node_modules` to preload, because that files all preload together will cause my debug efficiency.
#### Example - preload exclude all node_modules.
```bash
node-inspector  --preload-exclude .*\\/node_modules\\/.*
```
But I found that even though I blocked these files, still very slow startup times.   I rewrote `listScripts` in ScriptFileStorage.js.  

Now It can be very fast startup times, and even if  did not use `--preload-exclude .*\\/node_modules\\/.*`