### PR TITLE
Minor Plugin API Extensions

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -99,6 +99,16 @@ var definitions = {
     _isNodeInspectorOption: true,
     default: false
   },
+  'plugin-path': {
+    type: 'string',
+    description: 'The path from which to load node-inspector plugins.\n' +
+               '  Used only if the --plugins option is set to true.\n',
+    usage: {
+      '--plugin-path $HOME/node-inspector-plugins': 'load plugins from the given path',
+    },
+    _isNodeInspectorOption: true,
+    default: ''
+  },
   'hidden': {
     type: 'string',
     description: 'Array of files to hide from the UI.' +

--- a/lib/debug-server.js
+++ b/lib/debug-server.js
@@ -14,7 +14,6 @@ var http = require('http'),
     plugins = require('./plugins'),
     InspectorJson = plugins.InspectorJson,
     ProtocolJson = plugins.ProtocolJson,
-    PLUGINS = plugins.cwd,
     OVERRIDES = path.join(__dirname, '../front-end-node'),
     WEBROOT = path.join(__dirname, '../front-end');
 
@@ -85,8 +84,13 @@ inherits(DebugServer, EventEmitter);
 DebugServer.prototype.start = function(options) {
   this._config = extend({}, options);
   this._isHTTPS = this._config.sslKey && this._config.sslCert ? true : false;
+
+  plugins.init(this._config);
+
   this._inspectorJson = new InspectorJson(this._config);
   this._protocolJson = new ProtocolJson(this._config);
+
+  var PLUGINS = plugins.CWD;
 
   var app = express();
   var httpServer;

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -2,8 +2,11 @@ var fs = require('fs'),
     inherits = require('util').inherits,
     path = require('path');
 
-var CWD = path.join(__dirname, '../plugins'),
-    THROW_CONFLICTS = true;
+var THROW_CONFLICTS = true;
+
+function getPluginPath(config) {
+  return (config && config.pluginPath) || path.join(__dirname, '../plugins');
+}
 
 function PluginError(message) {
   this.name = 'Plugin Error';
@@ -30,18 +33,35 @@ function mergeByName(acceptor, donor, name, onConflict) {
   }, this);
 }
 
-var plugins = [],
-    dirlist;
+var cachedPlugins = {};
 
-try {
-  dirlist = fs.readdirSync(CWD);
-} catch (err) {
-  dirlist = [];
+function _setMockPlugins(pluginPath, plugins) {
+  cachedPlugins[pluginPath] = plugins;
 }
-  
-dirlist.reduce(function(plugins, subdir) {
-    var _path = path.resolve(CWD, subdir, 'manifest.json'),
-        manifest;
+
+function getPlugins(config) {
+  if (!config || !config.plugins) {
+    return [];
+  }
+
+  var pluginPath = getPluginPath(config);
+  if (cachedPlugins[pluginPath])  {
+    return cachedPlugins[pluginPath];
+  }
+
+  var dirlist;
+
+  try {
+    dirlist = fs.readdirSync(pluginPath);
+  } catch (err) {
+    dirlist = [];
+  }
+
+  var plugins = [];
+
+  dirlist.reduce(function(plugins, subdir) {
+    var _path = path.resolve(pluginPath, subdir, 'manifest.json');
+    var manifest;
 
     try {
       manifest = require(_path);
@@ -59,10 +79,14 @@ dirlist.reduce(function(plugins, subdir) {
     return plugins;
   }, plugins);
 
+  cachedPlugins[pluginPath] = plugins;
+  return plugins;
+}
+
 function validateManifest(manifest) {
   manifest.session = manifest.session || {};
   manifest.protocol = manifest.protocol || {};
-  manifest.protocol.domains = manifest.protocol.domains || []; 
+  manifest.protocol.domains = manifest.protocol.domains || [];
 }
 
 function InspectorJson(config) {
@@ -77,6 +101,8 @@ function InspectorJson(config) {
   this._merge(extendedInspectorJson);
 
   if (!config.plugins) return;
+
+  var plugins = getPlugins(config);
 
   plugins.forEach(function(plugin) {
     var excludes = (plugin.exclude || []).map(function(name) {
@@ -130,6 +156,7 @@ function ProtocolJson(config) {
   this._extendedDomains = extendedProtocolJson.domains;
 
   if (config.plugins) {
+    var plugins = getPlugins(config);
     // At first step we merge all plugins in one protocol.
     // We expect what plugins doesn't have equal methods, events or types,
     // otherwise we throw an error, because this is unsolvable situation.
@@ -207,11 +234,17 @@ ProtocolJson.prototype.toJSON = function() {
   return this._protocol;
 };
 
+function init(config) {
+  module.exports.CWD = getPluginPath(config);
+}
+
 module.exports = {
-  cwd: CWD,
-  list: plugins,
+  _setMockPlugins: _setMockPlugins,
+  getPluginPath: getPluginPath,
+  getPlugins: getPlugins,
   validateManifest: validateManifest,
   PluginError: PluginError,
   InspectorJson: InspectorJson,
-  ProtocolJson: ProtocolJson
+  ProtocolJson: ProtocolJson,
+  init: init
 };

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -109,12 +109,14 @@ function InspectorJson(config) {
       return { name: name, type: 'exclude' };
     });
 
+    var overrides = plugin.override || [];
+
     var note = {
       name: 'plugins/' + plugin.name,
       type: plugin.type || ''
     };
 
-    var notes = excludes.concat(note);
+    var notes = excludes.concat(overrides).concat(note);
 
     this._merge(notes);
   }, this);

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -90,6 +90,28 @@ describe('Plugins', function() {
       expect(findEq(inspectorJson._notes, 'name', excludeTarget.name)).to.equal(undefined);
     });
 
+    it('should work correctly with `manifest.override`', function() {
+      var inspectorJson = new InspectorJson({ plugins: false });
+
+      var overrideTarget = inspectorJson._notes[0];
+      var manifest = {
+        name: 'test-plugin',
+        type: 'autostart',
+        override: [{ name: overrideTarget.name, type: 'test' }]
+      };
+      plugins.validateManifest(manifest);
+      plugins.getPlugins({ plugins: true }).push(manifest);
+
+      expect(overrideTarget).to.be.instanceof(Object);
+      expect(findEq(inspectorJson._notes, 'name', overrideTarget.name)).to.not.equal(undefined);
+      expect(findEq(inspectorJson._notes, 'type', 'test')).to.equal(undefined);
+
+      inspectorJson = new InspectorJson({ plugins: true });
+
+      expect(findEq(inspectorJson._notes, 'name', overrideTarget.name)).to.not.equal(undefined);
+      expect(findEq(inspectorJson._notes, 'type', 'test')).to.not.equal(undefined);
+    });
+
     it('should correctly stringify itself', function() {
       var manifest = addCommonPlugin();
       var inspectorJson = new InspectorJson({ plugins: true });

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -2,7 +2,8 @@ var expect = require('chai').expect,
     plugins = require('../lib/plugins'),
     PluginError = plugins.PluginError,
     ProtocolJson = plugins.ProtocolJson,
-    InspectorJson = plugins.InspectorJson;
+    InspectorJson = plugins.InspectorJson,
+    defaultPluginPath = plugins.getPluginPath();
 
 function findEq(collection, option, value) {
   return collection.filter(function(item) {
@@ -11,7 +12,7 @@ function findEq(collection, option, value) {
 }
 
 function clearPlugins() {
-  plugins.list.length = 0;
+  plugins._setMockPlugins(defaultPluginPath, []);
 }
 
 function addCommonPlugin() {
@@ -20,7 +21,7 @@ function addCommonPlugin() {
     type: 'autostart'
   };
   plugins.validateManifest(manifest);
-  plugins.list.push(manifest);
+  plugins.getPlugins({ plugins: true }).push(manifest);
 
   return manifest;
 }
@@ -43,7 +44,7 @@ function addPluginWithProtocol() {
     }
   };
   plugins.validateManifest(manifest);
-  plugins.list.push(manifest);
+  plugins.getPlugins({ plugins: true }).push(manifest);
 
   return manifest;
 }
@@ -69,7 +70,7 @@ describe('Plugins', function() {
       });
     });
 
-    it('should works correctly with `manifest.exclude`', function() {
+    it('should work correctly with `manifest.exclude`', function() {
       var inspectorJson = new InspectorJson({ plugins: false });
 
       var excludeTarget = inspectorJson._notes[0];
@@ -79,7 +80,7 @@ describe('Plugins', function() {
         exclude: [excludeTarget.name]
       };
       plugins.validateManifest(manifest);
-      plugins.list.push(manifest);
+      plugins.getPlugins({ plugins: true }).push(manifest);
 
       expect(excludeTarget).to.be.instanceof(Object);
       expect(findEq(inspectorJson._notes, 'name', excludeTarget.name)).to.not.equal(undefined);
@@ -102,7 +103,7 @@ describe('Plugins', function() {
       });
     });
   });
-  
+
   describe('ProtocolJson', function() {
     beforeEach(clearPlugins);
 
@@ -148,8 +149,8 @@ describe('Plugins', function() {
         }
       };
       plugins.validateManifest(manifest_conflict);
-      plugins.list.push(manifest_conflict);
-      
+      plugins.getPlugins({ plugins: true }).push(manifest_conflict);
+
       var protocolJson = new ProtocolJson({ plugins: true });
       var targetName = manifest.protocol.domains[0].domain;
 
@@ -185,7 +186,7 @@ describe('Plugins', function() {
         }
       };
       plugins.validateManifest(manifest_conflict);
-      plugins.list.push(manifest_conflict);
+      plugins.getPlugins({ plugins: true }).push(manifest_conflict);
 
       expect(function() { return new ProtocolJson({ plugins: true }); }).to.throw(PluginError);
     });


### PR DESCRIPTION
#### Overview

Hello! I'd like to make a few minor changes to the plugin API which will make it easier to keep the vanilla node-inspector source tree untouched (and up to date) and ship plugins alongside.

I'm using node-inspector plus some custom plugins to provide JS debugging support for the Netflix application on TVs and game consoles.

This change would make it so I can stop shipping a forked version :)

#### Proposed Changes
* Added --plugin-path argument for specifying root plugin path when plugins are enabled.
* Added plugin/manifest.json "override" property to allow finer-grained control of inspector.json.