### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ so that sources earlier in this list override later ones.
 | --help              | -h  |         | Display information about available options.<br/>Use `--help -l` to display full usage info.<br/>Use `--help <option>` to display quick help on `option`.
 | --version           | -v  |         | Display Node Inspector's version.
 | --debug-port        | -d  | 5858    | Node/V8 debugger port.<br/>(`node --debug={port}`)
-| --web-host          |     | 0.0.0.0 | Host to listen on for Node Inspector's web interface.<br/>`node-debug` listens on `127.0.0.1` by default.
+| --web-host          |     | 127.0.0.1 | Host to listen on for Node Inspector's web interface.<br/>`node-debug` listens on `127.0.0.1` by default. To listen on all available network interfaces use ```--web-host 0.0.0.0```.
 | --web-port          | -p  | 8080    | Port to listen on for Node Inspector's web interface.
 | **node-debug**
 | --debug-brk         | -b  | true    | Break on the first line.<br/>(`node --debug-brk`)


### PR DESCRIPTION
In the description it says "defaults to 127.0.0.1", so this should also be stated in "Default" column.

Furthermore the output ```Node Inspector is now available from http://127.0.0.1:8080/?ws=127.0.0.1:8080&port=5858```should perhaps get adjusted to point out that when connecting from remote machine (or just vm host) both occurrences of ```127.0.0.1```have to be replaced.