### PR TITLE
Bump ws dependency to 1.0.1 (eliminates dependency on bufferutil)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "v8-debug": "~0.7.1",
     "v8-profiler": "~5.6.0",
     "which": "^1.1.1",
-    "ws": "^0.8.0",
+    "ws": "^1.0.1",
     "yargs": "^3.9.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes issue #767.  Starting with version 1.0.0, ws no longer depends on bufferutil, eliminating the need to install a compiler on Windows and the whole node-gyp thing.