### PR TITLE
Fix issue #832, "node inspector and babel-register".

### DIFF
--- a/lib/ScriptManager.js
+++ b/lib/ScriptManager.js
@@ -241,7 +241,10 @@ ScriptManager.prototype = Object.create(events.EventEmitter.prototype, {
 
   _checkSourceMapIssues: {
     value: function(inspectorScriptData, sourceMap) {
-      var scriptName = inspectorScriptData.url.replace(/^file:\/\/\//, '');
+      var scriptName = inspectorScriptData.url.replace(/^file:\/\//, '');
+      if (process.platform == 'win32') {
+        scriptName = scriptName.replace(/^\//, '');
+      }
       var scriptOrigin = path.dirname(scriptName);
       fixAbsoluteSourcePaths();
       fixWrongFileName();
@@ -291,7 +294,11 @@ ScriptManager.prototype = Object.create(events.EventEmitter.prototype, {
 
   normalizeName: {
     value: function(name) {
-      if (this._isMainAppScript(name.replace(/^file:\/\/\//, ''))) {
+      var scriptName = name.replace(/^file:\/\//, '');
+      if (process.platform == 'win32') {
+        scriptName = scriptName.replace(/^\//, '');
+      }
+      if (this._isMainAppScript(scriptName)) {
         return convert.v8NameToInspectorUrl(this.mainAppScript);
       }
 

--- a/test/ScriptManager.js
+++ b/test/ScriptManager.js
@@ -75,11 +75,42 @@ describe('ScriptManager', function() {
         var name = manager.normalizeName(realMainAppScript);
         expect(name).to.equal(mainAppScript);
       });
+
+      it('returns case sensitive URL for main script on Windows', function() {
+        manager.realMainAppScript = 'C:\\' + realMainAppScript;
+        manager.mainAppScript = 'C:\\' + mainAppScript;
+        var url = 'file:///C:/' + realMainAppScript.replace(/\\/g, '/');
+        var normalized_name = manager.normalizeName(url);
+        expect(normalized_name).to.equal('file:///C:/' + mainAppScript.replace(/\\/g, '/'));
+      });
+
+      it('returns unchanged URL for not main script on Windows', function() {
+        manager.realMainAppScript = 'C:\\' + realMainAppScript;
+        manager.mainAppScript = 'C:\\' + mainAppScript;
+        var url = 'file:///C:/folder/app1.js';
+        var normalized_name = manager.normalizeName(url);
+        expect(normalized_name).to.equal(url);
+      });
     } else {
       it('returns unchanged name for main script on Linux', function() {
-        var name = manager.normalizeName('folder/app.js');
         var normalized_name = manager.normalizeName(realMainAppScript);
         expect(normalized_name).to.equal(realMainAppScript);
+      });
+
+      it('returns unchanged URL for main script on Linux', function() {
+        manager.realMainAppScript = '/' + realMainAppScript;
+        manager.mainAppScript = '/' + mainAppScript;
+        var url = 'file:///' + realMainAppScript;
+        var normalized_name = manager.normalizeName(url);
+        expect(normalized_name).to.equal(url);
+      });
+
+      it('returns unchanged URL for not main script on Linux', function() {
+        manager.realMainAppScript = '/' + realMainAppScript;
+        manager.mainAppScript = '/' + mainAppScript;
+        var url = 'file:///folder/App1.js';
+        var normalized_name = manager.normalizeName(url);
+        expect(normalized_name).to.equal(url);
       });
     }
 
@@ -87,6 +118,20 @@ describe('ScriptManager', function() {
       var name = 'folder/app1.js';
       var normalized_name = manager.normalizeName(name);
       expect(normalized_name).to.equal(name);
+    });
+  });
+
+  describe('_checkSourceMapIssues()', function() {
+    it('fixes sourcemap source file name when it duplicates the target file name', function() {
+      var url = (process.platform == 'win32') ? 'file:///C:/folder/file.js' : 'file:///folder/file.js';
+      var inspectorScriptData = {
+        url: url
+      };
+      var sourceMap = {
+        sources: ['file.js']
+      };
+      manager._checkSourceMapIssues(inspectorScriptData, sourceMap);
+      expect(sourceMap.sources[0]).to.equal('file.js.source');
     });
   });
 });


### PR DESCRIPTION
This fixes the issue on Mac OSX where it appears to be impossible to
enable any breakpoints while debugging ES6 code dynamically transpiled
by either babel-node or babel-register.
The initial cause of the problem is that the source and the target file
names in source maps produced by babel-register are exactly equal and
have no paths.
node-inspector already contains code that addresses this problem:
_checkSourceMapIssues()/fixWrongFileName() in lib/ScriptManager.js,
which appends ".source" extension to the source file name in the source
map, when name duplication is detected. Unfortunately the code converting
URLs to absolute paths in that method does not work correctly with
Linux/OSX URLs: it strips the root slash from the path thus rendering
path invalid. This commit fixes this bug and also, exactly same bug
in lib/ScriptManager.normalizeName().