### PR TITLE
Fix for #827. Added a "web-port" option to be usable by `node-debug` binary

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -37,6 +37,7 @@ var definitions = {
       '-p 8081': ''
     },
     _isNodeInspectorOption: true,
+    _isNodeDebugOption: true,
     default: '8080'
   },
   'web-host': {


### PR DESCRIPTION
In `config.js` I just added the property `_isNodeDebugOption: true,` to the `'web-port'` option.  This appears to solve #827.  Is seems like there may be some additional options that need that flag too, like `'web-host'` for example, but I'm not entirely certain, so I left it off this PR.