### PR TITLE
Allow bind to 0.0.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ exports.buildWebSocketUrl = buildWebSocketUrl;
  * @param {number} isHttps as configured via --ssl-cert and --ssl-key in the debugged app
  */
 function buildInspectorUrl(inspectorHost, inspectorPort, debugPort, isHttps) {
-  var host = inspectorHost == '0.0.0.0' ? '127.0.0.1' : inspectorHost;
+  var host = inspectorHost;
   var port = inspectorPort;
   var protocol = isHttps ? 'https' : 'http';
 


### PR DESCRIPTION
This is fundamental for people trying to use node-inspector to debug js code that resides in a container.
