### PR TITLE
Fix callback call in InjectorClient._findNMInScope

### DIFF
--- a/lib/InjectorClient.js
+++ b/lib/InjectorClient.js
@@ -108,7 +108,7 @@ InjectorClient.prototype._findNMInScope = function(funcHandle, cb) {
       if (!NM.length)
         error = new Error('No NativeModule in target scope');
 
-      cb(error, NM[0].ref);
+      cb(error, error ? null : NM[0].ref);
     }.bind(this));
 };
 


### PR DESCRIPTION
When error is defined (in this case it means that NM is doen't have any elements) callback calling will be throwing an exception. Because in this case NM[0] is not defined. So we need to check the error variable.
