### PR TITLE
Support unix sockets as debug port

### DIFF
--- a/lib/debug-server.js
+++ b/lib/debug-server.js
@@ -141,7 +141,8 @@ DebugServer.prototype.start = function(options) {
 };
 
 DebugServer.prototype._getDebuggerPort = function(url) {
-  return parseInt((/[\?\&]port=(\d+)/.exec(url) || [null, this._config.debugPort])[1], 10);
+  // may be a port or a unix socket
+  return (/[\?\&]port=(.*)\&?/.exec(url) || [null, this._config.debugPort])[1];
 };
 
 DebugServer.prototype._getUrlFromReq = function(req) {


### PR DESCRIPTION
Node.js forks may accept unix sockets in their debug connection.
Make sure 'debugPort' is no longer treated as a Number but as a
plain string.