### PR TITLE
Notify about session closing

### DIFF
--- a/bin/inspector.js
+++ b/bin/inspector.js
@@ -27,6 +27,7 @@ console.log('Node Inspector v%s', packageJson.version);
 var debugServer = new DebugServer();
 debugServer.on('error', onError);
 debugServer.on('listening', onListening);
+debugServer.on('sessionClose', onSessionClose);
 debugServer.on('close', function () {
   process.exit();
 });
@@ -60,6 +61,12 @@ function onListening() {
   notifyParentProcess({
     event: 'SERVER.LISTENING',
     address: address
+  });
+}
+
+function onSessionClose() {
+  notifyParentProcess({
+    event: 'SERVER.SESSION_CLOSE'
   });
 }
 

--- a/lib/debug-server.js
+++ b/lib/debug-server.js
@@ -58,7 +58,12 @@ function protocolJson(req, res) {
 
 function handleWebSocketConnection(socket) {
   var debugPort = this._getDebuggerPort(socket.upgradeReq.url);
-  this._createSession(debugPort, socket);
+  var session = this._createSession(debugPort, socket);
+  session.on('close', handleSessionClose.bind(this));
+}
+
+function handleSessionClose() {
+  this.emit('sessionClose');
 }
 
 function handleServerListening() {


### PR DESCRIPTION
The event of the debug session being closed is of interest for callers
of node inspector.  For example they might decide to kill the inspector
process in this case.