### PR TITLE
Fixes immediate WS disconnect error with NodeJS v6.3+

### DIFF
--- a/lib/InjectorClient.js
+++ b/lib/InjectorClient.js
@@ -105,10 +105,10 @@ InjectorClient.prototype._findNMInScope = function(funcHandle, cb) {
         return prop.name == 'NativeModule';
       });
 
-      if (!NM.length)
-        error = new Error('No NativeModule in target scope');
+      if (!NM.length || !NM[0])
+        return cb(new Error('No NativeModule in target scope'));
 
-      cb(error, NM[0].ref);
+      cb(null, NM[0].ref);
     }.bind(this));
 };
 


### PR DESCRIPTION
Fixes small error in handling error condition vs. having an actual native module to return:

```
TypeError: Cannot read property 'ref' of undefined
    at InjectorClient.<anonymous> (/usr/lib/node_modules/node-inspector/lib/InjectorClient.js:111:22)
    at /usr/lib/node_modules/node-inspector/lib/DebuggerClient.js:121:7
    at Object.value (/usr/lib/node_modules/node-inspector/lib/callback.js:23:20)
    at Debugger._processResponse (/usr/lib/node_modules/node-inspector/lib/debugger.js:95:21)
    at Protocol.execute (_debugger.js:121:14)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at readableAddChunk (_stream_readable.js:176:18)
    at Socket.Readable.push (_stream_readable.js:134:10)
    at TCP.onread (net.js:543:20)
```

Reference issues:
- https://github.com/node-inspector/node-inspector/issues/905
- https://github.com/node-inspector/node-inspector/issues/907
- https://github.com/node-inspector/node-inspector/issues/928
- https://github.com/node-inspector/node-inspector/issues/931
