### PR TITLE
Avoid NodeJS 6.7.0 error

### DIFF
--- a/lib/InjectorClient.js
+++ b/lib/InjectorClient.js
@@ -104,11 +104,11 @@ InjectorClient.prototype._findNMInScope = function(funcHandle, cb) {
       var NM = refs[result.object.ref].properties.filter(function(prop) {
         return prop.name == 'NativeModule';
       });
-
-      if (!NM.length)
-        error = new Error('No NativeModule in target scope');
-
-      cb(error, NM[0].ref);
+  
+      if (NM.length)
+        cb(null, NM[0].ref);
+      else
+        cb(new Error('No NativeModule in target scope'));
     }.bind(this));
 };
 


### PR DESCRIPTION
This change fixes #905 + it avoids first argument reassignment.