### PR TITLE
patched InjectorClient.js for compatibility above nodejs version 6.3.1

### DIFF
--- a/lib/InjectorClient.js
+++ b/lib/InjectorClient.js
@@ -105,10 +105,11 @@ InjectorClient.prototype._findNMInScope = function(funcHandle, cb) {
         return prop.name == 'NativeModule';
       });
 
-      if (!NM.length)
-        error = new Error('No NativeModule in target scope');
+      if (!NM.length) error = new Error('No NativeModule in target scope');
 
-      cb(error, NM[0].ref);
+      if(NM.length > 0) cb(error, NM[0].ref);
+      else cb(error, null);
+
     }.bind(this));
 };
 


### PR DESCRIPTION
Despite the console log "Error: No NativeModule in target scope", which still needs addressing, this patch does enable it to work, with latest (nodejs 6.9.0)
many others to recognize for this @Virtual-Machine @asi-jmasson @dbreese