### PR TITLE
KeyboardEvent.key instead of KeyboardEvent.keyIdentifier  in front-end 

### DIFF
--- a/front-end/platform/DOMExtension.js
+++ b/front-end/platform/DOMExtension.js
@@ -778,7 +778,7 @@ Document.prototype.deepElementFromPoint = function(x, y)
  */
 function isEnterKey(event) {
     // Check if in IME.
-    return event.keyCode !== 229 && event.keyIdentifier === "Enter";
+    return event.keyCode !== 229 && (event.keyIdentifier === "Enter" || event.key === "Enter");
 }
 
 function consumeEvent(e)


### PR DESCRIPTION
As `KeyboardEvent.keyIdentifier` is removed from the recent browsers 
including chrome 54 rev, front-end should use `KeyboardEvent.key` instead.

(note.)
[https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyIdentifier](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyIdentifier)