### PR TITLE
Added license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Web Inspector based nodeJS debugger",
   "homepage": "http://github.com/node-inspector/node-inspector",
   "author": "Danny Coates <dannycoates@gmail.com>",
+  "license": "BSD-2-Clause",
   "keywords": [
     "debug",
     "debugger",


### PR DESCRIPTION
Adding this info helps me use the `license-report` package to make my company's tech stack audits easier.